### PR TITLE
feat: Story 3.2 — Confluence Content Crawler

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -128,3 +128,38 @@ KG_NEO4J_DATABASE=neo4j
 # by setting the same connection details for both. They use different node labels:
 # - Vector DB: Document, CodeExample, Source nodes
 # - Knowledge Graph: Repository, File, Class, Function, Method nodes
+
+# ─── Confluence Integration ─────────────────────────────────────────
+# Base URL of your Confluence instance
+CONFLUENCE_URL=https://your-org.atlassian.net
+
+# Deployment type (auto-detected from URL if not set): cloud, on_prem, data_center
+# CONFLUENCE_DEPLOYMENT_TYPE=cloud
+
+# Auth method (auto-detected from available credentials if not set): basic, pat, oauth2
+# CONFLUENCE_AUTH_METHOD=basic
+
+# Basic Auth (Cloud) — email + API token
+CONFLUENCE_USERNAME=your_email@example.com
+CONFLUENCE_API_TOKEN=your_confluence_api_token
+
+# Personal Access Token (On-Prem / Data Center)
+# CONFLUENCE_PAT=your_personal_access_token
+
+# OAuth 2.0 (Cloud Enterprise) — run scripts/confluence_oauth_setup.py to obtain tokens
+# CONFLUENCE_OAUTH2_CLIENT_ID=your_oauth2_client_id
+# CONFLUENCE_OAUTH2_CLIENT_SECRET=your_oauth2_client_secret
+# CONFLUENCE_OAUTH2_ACCESS_TOKEN=your_access_token
+# CONFLUENCE_OAUTH2_REFRESH_TOKEN=your_refresh_token
+# CONFLUENCE_OAUTH2_TOKEN_EXPIRES_AT=unix_timestamp
+# CONFLUENCE_CLOUD_ID=your_cloud_id
+
+# SSL Configuration
+# CONFLUENCE_SSL_VERIFY=true
+# CONFLUENCE_CA_BUNDLE=/path/to/ca-bundle.pem
+
+# Connection tuning
+# CONFLUENCE_TIMEOUT=30.0
+# CONFLUENCE_CONNECT_TIMEOUT=10.0
+# CONFLUENCE_POOL_SIZE=10
+# CONFLUENCE_MAX_RETRIES=3

--- a/scripts/confluence_oauth_setup.py
+++ b/scripts/confluence_oauth_setup.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""One-time CLI tool for Atlassian OAuth 2.0 3LO browser flow.
+
+Usage:
+    python scripts/confluence_oauth_setup.py \
+        --client-id YOUR_CLIENT_ID \
+        --client-secret YOUR_CLIENT_SECRET \
+        [--port 8089]
+
+The script starts a local HTTP server, opens the Atlassian authorization URL
+in the default browser, waits for the redirect callback, exchanges the
+authorization code for tokens, and prints the resulting environment variables.
+"""
+
+import argparse
+import http.server
+import json
+import os
+import sys
+import threading
+import urllib.parse
+import urllib.request
+import webbrowser
+
+AUTHORIZE_URL = "https://auth.atlassian.com/authorize"
+TOKEN_URL = "https://auth.atlassian.com/oauth/token"
+SCOPES = [
+    "read:confluence-content.all",
+    "read:confluence-space.summary",
+    "offline_access",  # needed for refresh_token
+]
+
+
+class CallbackHandler(http.server.BaseHTTPRequestHandler):
+    """Receives the OAuth redirect and extracts the authorization code."""
+
+    authorization_code = None
+
+    def do_GET(self):
+        parsed = urllib.parse.urlparse(self.path)
+        params = urllib.parse.parse_qs(parsed.query)
+        code = params.get("code", [None])[0]
+        if code:
+            CallbackHandler.authorization_code = code
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            self.wfile.write(
+                b"<h2>Authorization successful!</h2>"
+                b"<p>You can close this tab and return to the terminal.</p>"
+            )
+        else:
+            error = params.get("error", ["unknown"])[0]
+            self.send_response(400)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            self.wfile.write(f"<h2>Error: {error}</h2>".encode())
+
+    def log_message(self, format, *args):
+        pass  # suppress logs
+
+
+def exchange_code(client_id: str, client_secret: str, code: str, redirect_uri: str) -> dict:
+    payload = json.dumps({
+        "grant_type": "authorization_code",
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "code": code,
+        "redirect_uri": redirect_uri,
+    }).encode()
+    req = urllib.request.Request(
+        TOKEN_URL,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read())
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Atlassian OAuth 2.0 setup")
+    parser.add_argument("--client-id", required=True, help="OAuth2 client ID")
+    parser.add_argument("--client-secret", required=True, help="OAuth2 client secret")
+    parser.add_argument("--port", type=int, default=8089, help="Local callback port")
+    args = parser.parse_args()
+
+    redirect_uri = f"http://localhost:{args.port}/callback"
+
+    # Build authorize URL
+    params = urllib.parse.urlencode({
+        "audience": "api.atlassian.com",
+        "client_id": args.client_id,
+        "scope": " ".join(SCOPES),
+        "redirect_uri": redirect_uri,
+        "response_type": "code",
+        "prompt": "consent",
+    })
+    auth_url = f"{AUTHORIZE_URL}?{params}"
+
+    # Start local server
+    server = http.server.HTTPServer(("localhost", args.port), CallbackHandler)
+    thread = threading.Thread(target=server.handle_request, daemon=True)
+    thread.start()
+
+    print(f"Opening browser for authorization...\n{auth_url}\n")
+    webbrowser.open(auth_url)
+    print("Waiting for callback...")
+    thread.join(timeout=120)
+    server.server_close()
+
+    code = CallbackHandler.authorization_code
+    if not code:
+        print("ERROR: No authorization code received.", file=sys.stderr)
+        sys.exit(1)
+
+    print("Exchanging authorization code for tokens...")
+    tokens = exchange_code(args.client_id, args.client_secret, code, redirect_uri)
+
+    print("\n# Add these to your .env file:")
+    print(f"CONFLUENCE_OAUTH2_CLIENT_ID={args.client_id}")
+    print(f"CONFLUENCE_OAUTH2_CLIENT_SECRET={args.client_secret}")
+    print(f"CONFLUENCE_OAUTH2_ACCESS_TOKEN={tokens['access_token']}")
+    if "refresh_token" in tokens:
+        print(f"CONFLUENCE_OAUTH2_REFRESH_TOKEN={tokens['refresh_token']}")
+    if "expires_in" in tokens:
+        import time
+        expires_at = int(time.time() + tokens["expires_in"])
+        print(f"CONFLUENCE_OAUTH2_TOKEN_EXPIRES_AT={expires_at}")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_confluence_config.py
+++ b/scripts/validate_confluence_config.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Validate Confluence configuration from environment variables.
+
+Usage:
+    python scripts/validate_confluence_config.py
+"""
+
+import asyncio
+import sys
+import os
+
+# Ensure the project root is on sys.path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.atlassian import ConfluenceConfig, AtlassianAuthFactory, AtlassianConfigError
+
+
+async def main():
+    print("Validating Confluence configuration...\n")
+
+    # 1. Load config
+    try:
+        config = ConfluenceConfig.from_env()
+    except AtlassianConfigError as e:
+        print(f"FAIL  Configuration error: {e}")
+        sys.exit(1)
+
+    print(f"  URL:             {config.base_url}")
+    print(f"  Deployment type: {config.deployment_type.value}")
+    print(f"  Auth method:     {config.auth_method.value}")
+    print(f"  SSL verify:      {config.ssl_verify}")
+    print(f"  Pool size:       {config.pool_size}")
+    print(f"  Max retries:     {config.max_retries}")
+    print()
+
+    # 2. Create auth provider
+    try:
+        auth = AtlassianAuthFactory.create_auth_provider(config)
+    except Exception as e:
+        print(f"FAIL  Could not create auth provider: {e}")
+        sys.exit(1)
+
+    print(f"  Auth provider:   {type(auth).__name__}")
+
+    # 3. Health check (requires network)
+    try:
+        await auth.initialize()
+        health = await auth.health_check()
+        await auth.close()
+        if health.is_healthy:
+            print(f"  Health check:    PASS ({health.response_time_ms:.0f}ms)")
+        else:
+            print(f"  Health check:    FAIL - {health.error_message}")
+    except Exception as e:
+        print(f"  Health check:    SKIP (could not connect: {e})")
+
+    print("\nConfiguration is valid.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/atlassian/__init__.py
+++ b/src/atlassian/__init__.py
@@ -1,4 +1,4 @@
-"""Atlassian authentication and HTTP client package"""
+"""Atlassian authentication, HTTP client, and Confluence crawler package"""
 
 from .base import (
     AuthHeaders,
@@ -18,6 +18,8 @@ from .auth import (
     PATAuthProvider,
 )
 from .config import ConfluenceConfig
+from .confluence_crawler import ConfluenceCrawler, ConfluencePage, CrawlResult, CrawlSummary
+from .content_converter import ADFConverter, XHTMLConverter, convert_content
 from .factory import AtlassianAuthFactory
 from .http_client import AtlassianHTTPClient
 
@@ -41,6 +43,15 @@ __all__ = [
     "OAuth2AuthProvider",
     # Config
     "ConfluenceConfig",
+    # Content converters
+    "ADFConverter",
+    "XHTMLConverter",
+    "convert_content",
+    # Confluence crawler
+    "ConfluenceCrawler",
+    "ConfluencePage",
+    "CrawlResult",
+    "CrawlSummary",
     # Factory & client
     "AtlassianAuthFactory",
     "AtlassianHTTPClient",

--- a/src/atlassian/__init__.py
+++ b/src/atlassian/__init__.py
@@ -1,0 +1,47 @@
+"""Atlassian authentication and HTTP client package"""
+
+from .base import (
+    AuthHeaders,
+    AuthHealthStatus,
+    AuthMethod,
+    AtlassianAPIError,
+    AtlassianAuthError,
+    AtlassianConfigError,
+    AtlassianError,
+    AtlassianRateLimitError,
+    DeploymentType,
+)
+from .auth import (
+    AtlassianAuthProvider,
+    BasicAuthProvider,
+    OAuth2AuthProvider,
+    PATAuthProvider,
+)
+from .config import ConfluenceConfig
+from .factory import AtlassianAuthFactory
+from .http_client import AtlassianHTTPClient
+
+__all__ = [
+    # Enums
+    "DeploymentType",
+    "AuthMethod",
+    # Dataclasses
+    "AuthHeaders",
+    "AuthHealthStatus",
+    # Exceptions
+    "AtlassianError",
+    "AtlassianAuthError",
+    "AtlassianConfigError",
+    "AtlassianAPIError",
+    "AtlassianRateLimitError",
+    # Auth providers
+    "AtlassianAuthProvider",
+    "BasicAuthProvider",
+    "PATAuthProvider",
+    "OAuth2AuthProvider",
+    # Config
+    "ConfluenceConfig",
+    # Factory & client
+    "AtlassianAuthFactory",
+    "AtlassianHTTPClient",
+]

--- a/src/atlassian/auth/__init__.py
+++ b/src/atlassian/auth/__init__.py
@@ -1,0 +1,13 @@
+"""Atlassian authentication providers"""
+
+from .base_auth import AtlassianAuthProvider
+from .basic_auth import BasicAuthProvider
+from .pat_auth import PATAuthProvider
+from .oauth2_auth import OAuth2AuthProvider
+
+__all__ = [
+    "AtlassianAuthProvider",
+    "BasicAuthProvider",
+    "PATAuthProvider",
+    "OAuth2AuthProvider",
+]

--- a/src/atlassian/auth/base_auth.py
+++ b/src/atlassian/auth/base_auth.py
@@ -1,0 +1,65 @@
+"""Abstract base class for Atlassian authentication providers"""
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Dict, Any
+
+from ..base import AuthHeaders, AuthHealthStatus
+
+logger = logging.getLogger(__name__)
+
+
+class AtlassianAuthProvider(ABC):
+    """Abstract base class for Atlassian authentication providers.
+
+    Follows the pattern from ``src/ai_providers/base.py`` (EmbeddingProvider):
+    ``__init__`` accepts a config dict and calls ``_validate_config()`` immediately.
+    """
+
+    def __init__(self, config: Dict[str, Any]):
+        self.config = config
+        self._validate_config()
+
+    @abstractmethod
+    def _validate_config(self) -> None:
+        """Validate provider-specific configuration.
+
+        Raises:
+            AtlassianConfigError: If configuration is invalid.
+        """
+
+    async def initialize(self) -> None:
+        """Initialize any async resources (default no-op)."""
+
+    async def close(self) -> None:
+        """Release any async resources (default no-op)."""
+
+    @abstractmethod
+    async def get_auth_headers(self) -> AuthHeaders:
+        """Return current authentication headers.
+
+        Returns:
+            AuthHeaders with the appropriate Authorization header.
+        """
+
+    @abstractmethod
+    async def health_check(self) -> AuthHealthStatus:
+        """Verify credentials are valid by making a lightweight API call.
+
+        Returns:
+            AuthHealthStatus with result details.
+        """
+
+    @abstractmethod
+    async def is_token_valid(self) -> bool:
+        """Check whether the current token/credentials are still valid.
+
+        Returns:
+            True if valid, False otherwise.
+        """
+
+    async def refresh_if_needed(self) -> None:
+        """Refresh credentials if they are about to expire.
+
+        Default is a no-op. OAuth2 overrides this.
+        """

--- a/src/atlassian/auth/basic_auth.py
+++ b/src/atlassian/auth/basic_auth.py
@@ -1,0 +1,86 @@
+"""Basic authentication provider for Atlassian Cloud (email + API token)"""
+
+import base64
+import logging
+import time
+from typing import Dict, Any
+
+import aiohttp
+
+from ..base import AuthHeaders, AuthHealthStatus, AuthMethod, AtlassianConfigError
+from .base_auth import AtlassianAuthProvider
+
+logger = logging.getLogger(__name__)
+
+
+class BasicAuthProvider(AtlassianAuthProvider):
+    """Basic Auth for Atlassian Cloud: ``Authorization: Basic base64(email:api_token)``"""
+
+    def __init__(self, config: Dict[str, Any]):
+        super().__init__(config)
+        self.username = config["username"]
+        self.api_token = config["api_token"]
+        self.base_url = config["base_url"]
+
+    def _validate_config(self) -> None:
+        missing = []
+        if not self.config.get("username"):
+            missing.append("username")
+        if not self.config.get("api_token"):
+            missing.append("api_token")
+        if not self.config.get("base_url"):
+            missing.append("base_url")
+        if missing:
+            raise AtlassianConfigError(
+                f"BasicAuthProvider missing required config: {missing}"
+            )
+
+    async def get_auth_headers(self) -> AuthHeaders:
+        credentials = base64.b64encode(
+            f"{self.username}:{self.api_token}".encode()
+        ).decode()
+        return AuthHeaders(
+            headers={
+                "Authorization": f"Basic {credentials}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+            auth_method=AuthMethod.BASIC,
+        )
+
+    async def is_token_valid(self) -> bool:
+        # API tokens do not expire
+        return True
+
+    async def health_check(self) -> AuthHealthStatus:
+        start = time.time()
+        try:
+            auth = await self.get_auth_headers()
+            async with aiohttp.ClientSession() as session:
+                url = f"{self.base_url}/wiki/rest/api/space?limit=1"
+                async with session.get(url, headers=auth.headers) as resp:
+                    elapsed = (time.time() - start) * 1000
+                    if resp.status == 200:
+                        return AuthHealthStatus(
+                            is_healthy=True,
+                            auth_method=AuthMethod.BASIC.value,
+                            deployment_type="cloud",
+                            response_time_ms=elapsed,
+                        )
+                    body = await resp.text()
+                    return AuthHealthStatus(
+                        is_healthy=False,
+                        auth_method=AuthMethod.BASIC.value,
+                        deployment_type="cloud",
+                        response_time_ms=elapsed,
+                        error_message=f"HTTP {resp.status}: {body[:200]}",
+                    )
+        except Exception as e:
+            elapsed = (time.time() - start) * 1000
+            return AuthHealthStatus(
+                is_healthy=False,
+                auth_method=AuthMethod.BASIC.value,
+                deployment_type="cloud",
+                response_time_ms=elapsed,
+                error_message=str(e),
+            )

--- a/src/atlassian/auth/oauth2_auth.py
+++ b/src/atlassian/auth/oauth2_auth.py
@@ -1,0 +1,170 @@
+"""OAuth 2.0 (3-legged) authentication for Atlassian Cloud Enterprise"""
+
+import asyncio
+import logging
+import time
+from typing import Dict, Any, Optional
+
+import aiohttp
+
+from ..base import (
+    AuthHeaders,
+    AuthHealthStatus,
+    AuthMethod,
+    AtlassianAuthError,
+    AtlassianConfigError,
+)
+from .base_auth import AtlassianAuthProvider
+
+logger = logging.getLogger(__name__)
+
+TOKEN_URL = "https://auth.atlassian.com/oauth/token"
+EXPIRY_BUFFER_SECONDS = 300  # refresh 5 min before expiry
+
+
+class OAuth2AuthProvider(AtlassianAuthProvider):
+    """OAuth 2.0 3LO for Atlassian Cloud.
+
+    Tokens are expected to be pre-cached via env vars (headless operation) or
+    obtained through the ``scripts/confluence_oauth_setup.py`` browser flow.
+    Automatic refresh is performed via ``refresh_token`` grant.
+    """
+
+    REQUIRED_SCOPES = [
+        "read:confluence-content.all",
+        "read:confluence-space.summary",
+    ]
+
+    def __init__(self, config: Dict[str, Any]):
+        super().__init__(config)
+        self.client_id: str = config["oauth2_client_id"]
+        self.client_secret: str = config["oauth2_client_secret"]
+        self.base_url: str = config["base_url"]
+        self.cloud_id: Optional[str] = config.get("cloud_id")
+
+        # Tokens
+        self._access_token: Optional[str] = config.get("oauth2_access_token")
+        self._refresh_token: Optional[str] = config.get("oauth2_refresh_token")
+        self._expires_at: Optional[float] = None
+
+        if self._access_token and config.get("oauth2_token_expires_at"):
+            self._expires_at = float(config["oauth2_token_expires_at"])
+
+        # Concurrency guard for refresh
+        self._refresh_lock = asyncio.Lock()
+
+    def _validate_config(self) -> None:
+        missing = []
+        for key in ("oauth2_client_id", "oauth2_client_secret", "base_url"):
+            if not self.config.get(key):
+                missing.append(key)
+        if missing:
+            raise AtlassianConfigError(
+                f"OAuth2AuthProvider missing required config: {missing}"
+            )
+        # Must have either access_token or refresh_token to function
+        if not self.config.get("oauth2_access_token") and not self.config.get("oauth2_refresh_token"):
+            raise AtlassianConfigError(
+                "OAuth2AuthProvider requires at least one of "
+                "oauth2_access_token or oauth2_refresh_token"
+            )
+
+    async def get_auth_headers(self) -> AuthHeaders:
+        await self.refresh_if_needed()
+        if not self._access_token:
+            raise AtlassianAuthError("No access token available")
+        return AuthHeaders(
+            headers={
+                "Authorization": f"Bearer {self._access_token}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+            auth_method=AuthMethod.OAUTH2,
+            expires_at=self._expires_at,
+        )
+
+    async def is_token_valid(self) -> bool:
+        if not self._access_token:
+            return False
+        if self._expires_at is None:
+            return True  # Unknown expiry — assume valid
+        return time.time() < self._expires_at
+
+    async def refresh_if_needed(self) -> None:
+        """Proactively refresh the access token if it expires within the buffer window."""
+        if await self.is_token_valid():
+            # Still valid and not close to expiry
+            if self._expires_at is None or (self._expires_at - time.time()) > EXPIRY_BUFFER_SECONDS:
+                return
+
+        if not self._refresh_token:
+            logger.warning("Access token expired and no refresh token available")
+            return
+
+        async with self._refresh_lock:
+            # Double-check after acquiring lock (another coroutine may have refreshed)
+            if self._expires_at and (self._expires_at - time.time()) > EXPIRY_BUFFER_SECONDS:
+                return
+            await self._do_refresh()
+
+    async def _do_refresh(self) -> None:
+        logger.info("Refreshing OAuth2 access token")
+        payload = {
+            "grant_type": "refresh_token",
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "refresh_token": self._refresh_token,
+        }
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(TOKEN_URL, json=payload) as resp:
+                    if resp.status != 200:
+                        body = await resp.text()
+                        raise AtlassianAuthError(
+                            f"Token refresh failed (HTTP {resp.status}): {body[:300]}"
+                        )
+                    data = await resp.json()
+
+            self._access_token = data["access_token"]
+            if "refresh_token" in data:
+                self._refresh_token = data["refresh_token"]
+            expires_in = data.get("expires_in", 3600)
+            self._expires_at = time.time() + expires_in
+            logger.info("OAuth2 token refreshed, expires in %ds", expires_in)
+        except AtlassianAuthError:
+            raise
+        except Exception as e:
+            raise AtlassianAuthError(f"Token refresh error: {e}") from e
+
+    async def health_check(self) -> AuthHealthStatus:
+        start = time.time()
+        try:
+            auth = await self.get_auth_headers()
+            async with aiohttp.ClientSession() as session:
+                url = f"{self.base_url}/wiki/rest/api/space?limit=1"
+                async with session.get(url, headers=auth.headers) as resp:
+                    elapsed = (time.time() - start) * 1000
+                    if resp.status == 200:
+                        return AuthHealthStatus(
+                            is_healthy=True,
+                            auth_method=AuthMethod.OAUTH2.value,
+                            deployment_type="cloud",
+                            response_time_ms=elapsed,
+                        )
+                    body = await resp.text()
+                    return AuthHealthStatus(
+                        is_healthy=False,
+                        auth_method=AuthMethod.OAUTH2.value,
+                        deployment_type="cloud",
+                        response_time_ms=elapsed,
+                        error_message=f"HTTP {resp.status}: {body[:200]}",
+                    )
+        except Exception as e:
+            elapsed = (time.time() - start) * 1000
+            return AuthHealthStatus(
+                is_healthy=False,
+                auth_method=AuthMethod.OAUTH2.value,
+                deployment_type="cloud",
+                response_time_ms=elapsed,
+                error_message=str(e),
+            )

--- a/src/atlassian/auth/pat_auth.py
+++ b/src/atlassian/auth/pat_auth.py
@@ -1,0 +1,78 @@
+"""Personal Access Token (PAT) authentication for Atlassian On-Prem / Data Center"""
+
+import logging
+import time
+from typing import Dict, Any
+
+import aiohttp
+
+from ..base import AuthHeaders, AuthHealthStatus, AuthMethod, AtlassianConfigError
+from .base_auth import AtlassianAuthProvider
+
+logger = logging.getLogger(__name__)
+
+
+class PATAuthProvider(AtlassianAuthProvider):
+    """PAT Auth for On-Prem/DC: ``Authorization: Bearer {pat}``"""
+
+    def __init__(self, config: Dict[str, Any]):
+        super().__init__(config)
+        self.pat = config["pat"]
+        self.base_url = config["base_url"]
+
+    def _validate_config(self) -> None:
+        if not self.config.get("pat"):
+            raise AtlassianConfigError(
+                "PATAuthProvider missing required config: pat"
+            )
+        if not self.config.get("base_url"):
+            raise AtlassianConfigError(
+                "PATAuthProvider missing required config: base_url"
+            )
+
+    async def get_auth_headers(self) -> AuthHeaders:
+        return AuthHeaders(
+            headers={
+                "Authorization": f"Bearer {self.pat}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+            auth_method=AuthMethod.PAT,
+        )
+
+    async def is_token_valid(self) -> bool:
+        # PATs do not self-expire (admin can revoke them server-side)
+        return True
+
+    async def health_check(self) -> AuthHealthStatus:
+        start = time.time()
+        try:
+            auth = await self.get_auth_headers()
+            async with aiohttp.ClientSession() as session:
+                url = f"{self.base_url}/rest/api/space?limit=1"
+                async with session.get(url, headers=auth.headers) as resp:
+                    elapsed = (time.time() - start) * 1000
+                    if resp.status == 200:
+                        return AuthHealthStatus(
+                            is_healthy=True,
+                            auth_method=AuthMethod.PAT.value,
+                            deployment_type="on_prem",
+                            response_time_ms=elapsed,
+                        )
+                    body = await resp.text()
+                    return AuthHealthStatus(
+                        is_healthy=False,
+                        auth_method=AuthMethod.PAT.value,
+                        deployment_type="on_prem",
+                        response_time_ms=elapsed,
+                        error_message=f"HTTP {resp.status}: {body[:200]}",
+                    )
+        except Exception as e:
+            elapsed = (time.time() - start) * 1000
+            return AuthHealthStatus(
+                is_healthy=False,
+                auth_method=AuthMethod.PAT.value,
+                deployment_type="on_prem",
+                response_time_ms=elapsed,
+                error_message=str(e),
+            )

--- a/src/atlassian/base.py
+++ b/src/atlassian/base.py
@@ -1,0 +1,75 @@
+"""Base types, enums, dataclasses, and exceptions for Atlassian integration"""
+
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class DeploymentType(Enum):
+    """Atlassian deployment types"""
+    CLOUD = "cloud"
+    ON_PREM = "on_prem"
+    DATA_CENTER = "data_center"
+
+
+class AuthMethod(Enum):
+    """Supported authentication methods"""
+    BASIC = "basic"
+    PAT = "pat"
+    OAUTH2 = "oauth2"
+
+
+@dataclass
+class AuthHeaders:
+    """Authentication headers for Atlassian API requests"""
+    headers: Dict[str, str]
+    auth_method: AuthMethod
+    expires_at: Optional[float] = None
+
+
+@dataclass
+class AuthHealthStatus:
+    """Health check status for Atlassian authentication"""
+    is_healthy: bool
+    auth_method: str
+    deployment_type: str
+    response_time_ms: float
+    error_message: Optional[str] = None
+    metadata: Optional[Dict] = field(default_factory=dict)
+
+
+# --- Exceptions ---
+
+class AtlassianError(Exception):
+    """Base exception for all Atlassian-related errors"""
+    pass
+
+
+class AtlassianAuthError(AtlassianError):
+    """Authentication failure (invalid credentials, expired token, etc.)"""
+    pass
+
+
+class AtlassianConfigError(AtlassianError):
+    """Configuration validation error"""
+    pass
+
+
+class AtlassianAPIError(AtlassianError):
+    """Atlassian REST API error"""
+
+    def __init__(self, message: str, status_code: Optional[int] = None, response_body: Optional[str] = None):
+        super().__init__(message)
+        self.status_code = status_code
+        self.response_body = response_body
+
+
+class AtlassianRateLimitError(AtlassianAPIError):
+    """Rate limit exceeded (HTTP 429)"""
+
+    def __init__(self, message: str, retry_after: Optional[float] = None, **kwargs):
+        super().__init__(message, **kwargs)
+        self.retry_after = retry_after

--- a/src/atlassian/config.py
+++ b/src/atlassian/config.py
@@ -1,0 +1,199 @@
+"""Configuration management for Atlassian / Confluence integration"""
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Dict, Any, Optional
+
+from .base import AuthMethod, DeploymentType, AtlassianConfigError
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ConfluenceConfig:
+    """Confluence connection configuration.
+
+    Use ``ConfluenceConfig.from_env()`` to create an instance from environment
+    variables. Explicit env vars always override auto-detection.
+    """
+
+    base_url: str
+    deployment_type: DeploymentType
+    auth_method: AuthMethod
+    auth_config: Dict[str, Any] = field(default_factory=dict)
+
+    # SSL
+    ssl_verify: bool = True
+    ca_bundle: Optional[str] = None
+
+    # Timeouts
+    timeout: float = 30.0
+    connect_timeout: float = 10.0
+    pool_size: int = 10
+
+    # Rate-limit / retry
+    max_retries: int = 3
+
+    @classmethod
+    def from_env(cls) -> "ConfluenceConfig":
+        """Build configuration from ``CONFLUENCE_*`` environment variables.
+
+        Raises:
+            AtlassianConfigError: on invalid / missing configuration.
+        """
+        base_url = os.getenv("CONFLUENCE_URL", "").rstrip("/")
+        if not base_url:
+            raise AtlassianConfigError("CONFLUENCE_URL is required")
+        if not base_url.startswith(("http://", "https://")):
+            raise AtlassianConfigError(
+                "CONFLUENCE_URL must start with http:// or https://"
+            )
+
+        deployment_type = cls._resolve_deployment_type(base_url)
+        auth_method = cls._resolve_auth_method(deployment_type)
+        auth_config = cls._build_auth_config(auth_method, base_url)
+
+        # SSL
+        ssl_verify = os.getenv("CONFLUENCE_SSL_VERIFY", "true").lower() == "true"
+        ca_bundle = os.getenv("CONFLUENCE_CA_BUNDLE")
+        if ca_bundle and not os.path.isfile(ca_bundle):
+            raise AtlassianConfigError(
+                f"CA bundle file not found: {ca_bundle}"
+            )
+
+        # Timeouts / pool
+        timeout = float(os.getenv("CONFLUENCE_TIMEOUT", "30.0"))
+        connect_timeout = float(os.getenv("CONFLUENCE_CONNECT_TIMEOUT", "10.0"))
+        pool_size = int(os.getenv("CONFLUENCE_POOL_SIZE", "10"))
+        max_retries = int(os.getenv("CONFLUENCE_MAX_RETRIES", "3"))
+
+        config = cls(
+            base_url=base_url,
+            deployment_type=deployment_type,
+            auth_method=auth_method,
+            auth_config=auth_config,
+            ssl_verify=ssl_verify,
+            ca_bundle=ca_bundle,
+            timeout=timeout,
+            connect_timeout=connect_timeout,
+            pool_size=pool_size,
+            max_retries=max_retries,
+        )
+        config._validate()
+        return config
+
+    # ------------------------------------------------------------------
+    # Detection helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _resolve_deployment_type(url: str) -> DeploymentType:
+        explicit = os.getenv("CONFLUENCE_DEPLOYMENT_TYPE", "").lower()
+        if explicit:
+            try:
+                return DeploymentType(explicit)
+            except ValueError:
+                valid = [d.value for d in DeploymentType]
+                raise AtlassianConfigError(
+                    f"Invalid CONFLUENCE_DEPLOYMENT_TYPE='{explicit}'. Valid: {valid}"
+                )
+        # Auto-detect
+        if ".atlassian.net" in url:
+            return DeploymentType.CLOUD
+        return DeploymentType.ON_PREM
+
+    @staticmethod
+    def _resolve_auth_method(deployment_type: DeploymentType) -> AuthMethod:
+        explicit = os.getenv("CONFLUENCE_AUTH_METHOD", "").lower()
+        if explicit:
+            try:
+                return AuthMethod(explicit)
+            except ValueError:
+                valid = [a.value for a in AuthMethod]
+                raise AtlassianConfigError(
+                    f"Invalid CONFLUENCE_AUTH_METHOD='{explicit}'. Valid: {valid}"
+                )
+
+        # Auto-detect: OAuth2 > PAT > Basic
+        if os.getenv("CONFLUENCE_OAUTH2_CLIENT_ID"):
+            method = AuthMethod.OAUTH2
+        elif os.getenv("CONFLUENCE_PAT") or os.getenv("CONFLUENCE_API_TOKEN"):
+            if deployment_type == DeploymentType.CLOUD:
+                # On Cloud with only a token, assume Basic (email+token)
+                if os.getenv("CONFLUENCE_USERNAME"):
+                    method = AuthMethod.BASIC
+                else:
+                    method = AuthMethod.PAT
+            else:
+                method = AuthMethod.PAT
+        elif os.getenv("CONFLUENCE_USERNAME"):
+            method = AuthMethod.BASIC
+        else:
+            raise AtlassianConfigError(
+                "Cannot auto-detect auth method. Set CONFLUENCE_AUTH_METHOD or "
+                "provide credentials via CONFLUENCE_USERNAME/CONFLUENCE_API_TOKEN, "
+                "CONFLUENCE_PAT, or CONFLUENCE_OAUTH2_CLIENT_ID."
+            )
+        return method
+
+    @staticmethod
+    def _build_auth_config(auth_method: AuthMethod, base_url: str) -> Dict[str, Any]:
+        cfg: Dict[str, Any] = {"base_url": base_url}
+
+        if auth_method == AuthMethod.BASIC:
+            cfg["username"] = os.getenv("CONFLUENCE_USERNAME", "")
+            cfg["api_token"] = os.getenv("CONFLUENCE_API_TOKEN", "")
+
+        elif auth_method == AuthMethod.PAT:
+            cfg["pat"] = os.getenv("CONFLUENCE_PAT") or os.getenv("CONFLUENCE_API_TOKEN", "")
+
+        elif auth_method == AuthMethod.OAUTH2:
+            cfg["oauth2_client_id"] = os.getenv("CONFLUENCE_OAUTH2_CLIENT_ID", "")
+            cfg["oauth2_client_secret"] = os.getenv("CONFLUENCE_OAUTH2_CLIENT_SECRET", "")
+            cfg["oauth2_access_token"] = os.getenv("CONFLUENCE_OAUTH2_ACCESS_TOKEN")
+            cfg["oauth2_refresh_token"] = os.getenv("CONFLUENCE_OAUTH2_REFRESH_TOKEN")
+            cfg["oauth2_token_expires_at"] = os.getenv("CONFLUENCE_OAUTH2_TOKEN_EXPIRES_AT")
+            cfg["cloud_id"] = os.getenv("CONFLUENCE_CLOUD_ID")
+
+        return cfg
+
+    # ------------------------------------------------------------------
+    # Cross-field validation
+    # ------------------------------------------------------------------
+
+    def _validate(self) -> None:
+        if self.auth_method == AuthMethod.OAUTH2 and self.deployment_type != DeploymentType.CLOUD:
+            raise AtlassianConfigError(
+                "OAuth2 is only supported for Atlassian Cloud deployments"
+            )
+
+        if self.auth_method == AuthMethod.BASIC:
+            if not self.auth_config.get("username"):
+                raise AtlassianConfigError("CONFLUENCE_USERNAME is required for Basic auth")
+            if not self.auth_config.get("api_token"):
+                raise AtlassianConfigError("CONFLUENCE_API_TOKEN is required for Basic auth")
+
+        elif self.auth_method == AuthMethod.PAT:
+            if not self.auth_config.get("pat"):
+                raise AtlassianConfigError(
+                    "CONFLUENCE_PAT or CONFLUENCE_API_TOKEN is required for PAT auth"
+                )
+
+        elif self.auth_method == AuthMethod.OAUTH2:
+            if not self.auth_config.get("oauth2_client_id"):
+                raise AtlassianConfigError("CONFLUENCE_OAUTH2_CLIENT_ID is required")
+            if not self.auth_config.get("oauth2_client_secret"):
+                raise AtlassianConfigError("CONFLUENCE_OAUTH2_CLIENT_SECRET is required")
+            if not self.auth_config.get("oauth2_access_token") and not self.auth_config.get("oauth2_refresh_token"):
+                raise AtlassianConfigError(
+                    "At least CONFLUENCE_OAUTH2_ACCESS_TOKEN or "
+                    "CONFLUENCE_OAUTH2_REFRESH_TOKEN is required"
+                )
+
+        if self.timeout <= 0:
+            raise AtlassianConfigError("CONFLUENCE_TIMEOUT must be positive")
+        if self.connect_timeout <= 0:
+            raise AtlassianConfigError("CONFLUENCE_CONNECT_TIMEOUT must be positive")
+        if self.pool_size <= 0:
+            raise AtlassianConfigError("CONFLUENCE_POOL_SIZE must be positive")

--- a/src/atlassian/confluence_crawler.py
+++ b/src/atlassian/confluence_crawler.py
@@ -1,0 +1,415 @@
+"""Confluence content crawler — fetches pages via REST API and converts to Markdown"""
+
+import logging
+import os
+import re
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Set
+from urllib.parse import urlparse, parse_qs
+
+from .base import AtlassianAPIError, DeploymentType
+from .content_converter import convert_content
+from .http_client import AtlassianHTTPClient
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_PAGES = 100
+DEFAULT_MAX_DEPTH = 5
+
+
+@dataclass
+class ConfluencePage:
+    """A single crawled Confluence page."""
+
+    page_id: str
+    title: str
+    space_key: str
+    url: str
+    markdown_content: str
+    author: Optional[str] = None
+    created: Optional[str] = None
+    last_modified: Optional[str] = None
+    labels: List[str] = field(default_factory=list)
+    parent_page_id: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class CrawlSummary:
+    """Aggregate stats for a crawl operation."""
+
+    pages_succeeded: int = 0
+    pages_failed: int = 0
+    page_ids_crawled: Set[str] = field(default_factory=set)
+    errors: List[Dict[str, str]] = field(default_factory=list)
+
+
+@dataclass
+class CrawlResult:
+    """Result container for a crawl operation."""
+
+    pages: List[ConfluencePage] = field(default_factory=list)
+    summary: CrawlSummary = field(default_factory=CrawlSummary)
+    space_key: Optional[str] = None
+
+
+class ConfluenceCrawler:
+    """Crawls Confluence pages via REST API and converts content to Markdown.
+
+    Uses ``AtlassianHTTPClient.request()`` for all HTTP communication.
+    Cloud uses v2 API; On-Prem / Data Center uses v1 API.
+    """
+
+    def __init__(
+        self,
+        client: AtlassianHTTPClient,
+        deployment_type: DeploymentType,
+    ):
+        self.client = client
+        self.deployment_type = deployment_type
+        self.max_pages = int(os.getenv("CONFLUENCE_MAX_PAGES", str(DEFAULT_MAX_PAGES)))
+        self.max_depth = int(os.getenv("CONFLUENCE_MAX_DEPTH", str(DEFAULT_MAX_DEPTH)))
+
+    @property
+    def is_cloud(self) -> bool:
+        return self.deployment_type == DeploymentType.CLOUD
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def crawl_page(self, page_id: str) -> ConfluencePage:
+        """Crawl a single page by ID.
+
+        Raises:
+            AtlassianAPIError: on HTTP errors.
+        """
+        if self.is_cloud:
+            return await self._crawl_page_cloud(page_id)
+        return await self._crawl_page_onprem(page_id)
+
+    async def crawl_page_by_url(self, url: str) -> ConfluencePage:
+        """Parse a Confluence URL and crawl the identified page."""
+        page_id = self._parse_page_id_from_url(url)
+        return await self.crawl_page(page_id)
+
+    async def crawl_space(self, space_key: str) -> CrawlResult:
+        """Crawl all pages in a Confluence space (paginated)."""
+        result = CrawlResult(space_key=space_key)
+
+        if self.is_cloud:
+            page_ids = await self._list_space_pages_cloud(space_key)
+        else:
+            page_ids = await self._list_space_pages_onprem(space_key)
+
+        for pid in page_ids[: self.max_pages]:
+            if pid in result.summary.page_ids_crawled:
+                continue
+            await self._safe_crawl_page(pid, result)
+
+        return result
+
+    async def crawl_page_tree(self, root_page_id: str) -> CrawlResult:
+        """BFS crawl of a page tree starting from *root_page_id*.
+
+        Respects ``max_depth`` and ``max_pages``. Skips 403/404 pages.
+        """
+        result = CrawlResult()
+        queue: deque = deque()
+        queue.append((root_page_id, 0))
+        visited: Set[str] = set()
+
+        while queue and len(result.summary.page_ids_crawled) < self.max_pages:
+            page_id, depth = queue.popleft()
+
+            if page_id in visited:
+                continue
+            visited.add(page_id)
+
+            page = await self._safe_crawl_page(page_id, result)
+            if page is None:
+                continue
+
+            if depth < self.max_depth:
+                children = await self._get_child_page_ids(page_id)
+                for child_id in children:
+                    if child_id not in visited:
+                        queue.append((child_id, depth + 1))
+
+        return result
+
+    # ------------------------------------------------------------------
+    # Cloud (v2) implementation
+    # ------------------------------------------------------------------
+
+    async def _crawl_page_cloud(self, page_id: str) -> ConfluencePage:
+        data = await self.client.request(
+            "GET",
+            f"/wiki/api/v2/pages/{page_id}",
+            params={"body-format": "atlas_doc_format"},
+        )
+        return self._parse_cloud_page(data)
+
+    async def _list_space_pages_cloud(self, space_key: str) -> List[str]:
+        """List page IDs in a Cloud space using cursor pagination."""
+        page_ids: List[str] = []
+        # First resolve space ID from space key
+        spaces_data = await self.client.request(
+            "GET",
+            "/wiki/api/v2/spaces",
+            params={"keys": space_key, "limit": 1},
+        )
+        results = spaces_data.get("results", [])
+        if not results:
+            logger.warning("Space not found: %s", space_key)
+            return []
+        space_id = results[0]["id"]
+
+        cursor: Optional[str] = None
+        while len(page_ids) < self.max_pages:
+            params: Dict[str, Any] = {"limit": 25}
+            if cursor:
+                params["cursor"] = cursor
+            data = await self.client.request(
+                "GET",
+                f"/wiki/api/v2/spaces/{space_id}/pages",
+                params=params,
+            )
+            for page in data.get("results", []):
+                page_ids.append(str(page["id"]))
+
+            # Follow cursor
+            next_link = data.get("_links", {}).get("next")
+            if not next_link:
+                break
+            cursor = self._extract_cursor(next_link)
+            if not cursor:
+                break
+
+        return page_ids
+
+    def _parse_cloud_page(self, data: dict) -> ConfluencePage:
+        page_id = str(data["id"])
+        title = data.get("title", "")
+        space_key = data.get("spaceId", "")
+        # Extract space key from nested data if available
+        if "space" in data:
+            space_key = data["space"].get("key", space_key)
+
+        # Extract ADF body
+        body_data = data.get("body", {}).get("atlas_doc_format", {})
+        adf_value = body_data.get("value")
+        if isinstance(adf_value, str):
+            import json
+            try:
+                adf_value = json.loads(adf_value)
+            except (json.JSONDecodeError, TypeError):
+                adf_value = {}
+        markdown = convert_content(adf_value or {}, "adf")
+
+        # URL
+        base_link = data.get("_links", {}).get("base", "")
+        web_ui = data.get("_links", {}).get("webui", "")
+        url = f"{base_link}{web_ui}" if base_link else web_ui
+
+        # Version info
+        version = data.get("version", {})
+        author = version.get("by", {}).get("displayName") if version else None
+        created = data.get("createdAt")
+        last_modified = version.get("createdAt") if version else None
+
+        # Labels
+        labels = [
+            lbl.get("name", "") for lbl in data.get("labels", {}).get("results", [])
+        ]
+
+        # Parent
+        parent_id = data.get("parentId")
+
+        return ConfluencePage(
+            page_id=page_id,
+            title=title,
+            space_key=str(space_key),
+            url=url,
+            markdown_content=markdown,
+            author=author,
+            created=created,
+            last_modified=last_modified,
+            labels=labels,
+            parent_page_id=str(parent_id) if parent_id else None,
+        )
+
+    # ------------------------------------------------------------------
+    # On-Prem / Data Center (v1) implementation
+    # ------------------------------------------------------------------
+
+    async def _crawl_page_onprem(self, page_id: str) -> ConfluencePage:
+        data = await self.client.request(
+            "GET",
+            f"/rest/api/content/{page_id}",
+            params={"expand": "body.storage,metadata.labels,ancestors,version,space"},
+        )
+        return self._parse_onprem_page(data)
+
+    async def _list_space_pages_onprem(self, space_key: str) -> List[str]:
+        """List page IDs in an On-Prem space using offset pagination."""
+        page_ids: List[str] = []
+        start = 0
+        limit = 25
+
+        while len(page_ids) < self.max_pages:
+            data = await self.client.request(
+                "GET",
+                "/rest/api/content",
+                params={
+                    "spaceKey": space_key,
+                    "type": "page",
+                    "start": start,
+                    "limit": limit,
+                },
+            )
+            results = data.get("results", [])
+            if not results:
+                break
+            for page in results:
+                page_ids.append(str(page["id"]))
+
+            size = data.get("size", len(results))
+            if size < limit:
+                break
+            start += limit
+
+        return page_ids
+
+    def _parse_onprem_page(self, data: dict) -> ConfluencePage:
+        page_id = str(data["id"])
+        title = data.get("title", "")
+
+        space_key = data.get("space", {}).get("key", "")
+
+        # Storage format body
+        storage_body = data.get("body", {}).get("storage", {}).get("value", "")
+        markdown = convert_content(storage_body, "storage")
+
+        # URL
+        base_link = data.get("_links", {}).get("base", "")
+        web_ui = data.get("_links", {}).get("webui", "")
+        url = f"{base_link}{web_ui}" if base_link else web_ui
+
+        # Version info
+        version = data.get("version", {})
+        author = version.get("by", {}).get("displayName") if version else None
+        created = version.get("when") if version else None
+        last_modified = created  # v1 API stores version date in "when"
+
+        # Labels
+        labels_data = data.get("metadata", {}).get("labels", {})
+        labels = [lbl.get("name", "") for lbl in labels_data.get("results", [])]
+
+        # Parent from ancestors
+        ancestors = data.get("ancestors", [])
+        parent_id = str(ancestors[-1]["id"]) if ancestors else None
+
+        return ConfluencePage(
+            page_id=page_id,
+            title=title,
+            space_key=space_key,
+            url=url,
+            markdown_content=markdown,
+            author=author,
+            created=created,
+            last_modified=last_modified,
+            labels=labels,
+            parent_page_id=parent_id,
+        )
+
+    # ------------------------------------------------------------------
+    # Child page retrieval (for page tree crawl)
+    # ------------------------------------------------------------------
+
+    async def _get_child_page_ids(self, page_id: str) -> List[str]:
+        try:
+            if self.is_cloud:
+                data = await self.client.request(
+                    "GET",
+                    f"/wiki/api/v2/pages/{page_id}/children",
+                    params={"limit": 50},
+                )
+                return [str(p["id"]) for p in data.get("results", [])]
+            else:
+                data = await self.client.request(
+                    "GET",
+                    f"/rest/api/content/{page_id}/child/page",
+                    params={"limit": 50},
+                )
+                return [str(p["id"]) for p in data.get("results", [])]
+        except AtlassianAPIError as e:
+            logger.warning("Failed to get children for page %s: %s", page_id, e)
+            return []
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    async def _safe_crawl_page(
+        self, page_id: str, result: CrawlResult
+    ) -> Optional[ConfluencePage]:
+        """Crawl a page, catching 403/404 and recording errors."""
+        try:
+            page = await self.crawl_page(page_id)
+            result.pages.append(page)
+            result.summary.pages_succeeded += 1
+            result.summary.page_ids_crawled.add(page_id)
+            return page
+        except AtlassianAPIError as e:
+            status = getattr(e, "status_code", None)
+            if status in (403, 404):
+                logger.info("Skipping page %s (HTTP %s)", page_id, status)
+            else:
+                logger.warning("Error crawling page %s: %s", page_id, e)
+            result.summary.pages_failed += 1
+            result.summary.errors.append(
+                {"page_id": page_id, "error": str(e)}
+            )
+            return None
+
+    def _parse_page_id_from_url(self, url: str) -> str:
+        """Extract page ID from various Confluence URL formats.
+
+        Supports:
+        - Cloud: ``/wiki/spaces/KEY/pages/12345/Title``
+        - On-Prem: ``/pages/viewpage.action?pageId=12345``
+        - On-Prem: ``/display/KEY/Title`` (not directly resolvable — raises)
+        - Direct ID in path: ``/wiki/api/v2/pages/12345``
+        """
+        parsed = urlparse(url)
+        path = parsed.path
+
+        # pageId query param (On-Prem viewpage.action)
+        qs = parse_qs(parsed.query)
+        if "pageId" in qs:
+            return qs["pageId"][0]
+
+        # Cloud: /wiki/spaces/KEY/pages/{id}/...
+        match = re.search(r"/pages/(\d+)", path)
+        if match:
+            return match.group(1)
+
+        # API path: /wiki/api/v2/pages/{id}
+        match = re.search(r"/api/v[12]/pages/(\d+)", path)
+        if match:
+            return match.group(1)
+
+        # On-Prem: /rest/api/content/{id}
+        match = re.search(r"/rest/api/content/(\d+)", path)
+        if match:
+            return match.group(1)
+
+        raise ValueError(f"Cannot extract page ID from URL: {url}")
+
+    @staticmethod
+    def _extract_cursor(next_link: str) -> Optional[str]:
+        """Extract cursor value from a v2 pagination ``next`` link."""
+        match = re.search(r"[?&]cursor=([^&]+)", next_link)
+        return match.group(1) if match else None

--- a/src/atlassian/content_converter.py
+++ b/src/atlassian/content_converter.py
@@ -1,0 +1,473 @@
+"""ADF (Atlassian Document Format) and XHTML/Storage → Markdown converters"""
+
+import logging
+import re
+import xml.etree.ElementTree as ET
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class ADFConverter:
+    """Converts Atlassian Document Format (Cloud) JSON to Markdown."""
+
+    def convert(self, adf_doc: dict) -> str:
+        if not adf_doc or not isinstance(adf_doc, dict):
+            return ""
+        content = adf_doc.get("content", [])
+        parts = [self._convert_block(node) for node in content]
+        md = "\n\n".join(p for p in parts if p)
+        return md.strip()
+
+    def _convert_block(self, node: dict) -> str:
+        ntype = node.get("type", "")
+        attrs = node.get("attrs", {})
+        content = node.get("content", [])
+
+        if ntype == "heading":
+            level = attrs.get("level", 1)
+            text = self._convert_inline_children(content)
+            return f"{'#' * level} {text}"
+
+        if ntype == "paragraph":
+            return self._convert_inline_children(content)
+
+        if ntype == "codeBlock":
+            language = attrs.get("language", "")
+            text = self._extract_text(content)
+            return f"```{language}\n{text}\n```"
+
+        if ntype == "blockquote":
+            inner = self._convert_children_blocks(content)
+            return "\n".join(f"> {line}" for line in inner.split("\n"))
+
+        if ntype == "rule":
+            return "---"
+
+        if ntype == "bulletList":
+            return self._convert_list(content, ordered=False)
+
+        if ntype == "orderedList":
+            return self._convert_list(content, ordered=True)
+
+        if ntype == "table":
+            return self._convert_table(content)
+
+        if ntype == "panel":
+            panel_type = attrs.get("panelType", "info").capitalize()
+            inner = self._convert_children_blocks(content)
+            return f"> **{panel_type}:** {inner}"
+
+        if ntype == "expand":
+            title = attrs.get("title", "Details")
+            inner = self._convert_children_blocks(content)
+            return f"**{title}:** {inner}"
+
+        if ntype == "mediaSingle" or ntype == "mediaGroup":
+            return self._convert_children_blocks(content)
+
+        if ntype == "media":
+            alt = attrs.get("alt", "")
+            url = attrs.get("url", "")
+            return f"![{alt}]({url})"
+
+        # Fallback: try to render children
+        if content:
+            return self._convert_children_blocks(content)
+        return ""
+
+    def _convert_inline_children(self, nodes: list) -> str:
+        return "".join(self._convert_inline(n) for n in nodes)
+
+    def _convert_inline(self, node: dict) -> str:
+        ntype = node.get("type", "")
+
+        if ntype == "text":
+            text = node.get("text", "")
+            marks = node.get("marks", [])
+            return self._apply_marks(text, marks)
+
+        if ntype == "hardBreak":
+            return "\n"
+
+        if ntype == "inlineCard":
+            url = node.get("attrs", {}).get("url", "")
+            return f"[{url}]({url})"
+
+        if ntype == "mention":
+            name = node.get("attrs", {}).get("text", "")
+            if not name:
+                name = node.get("attrs", {}).get("id", "unknown")
+            return f"@{name}"
+
+        if ntype == "emoji":
+            return node.get("attrs", {}).get("shortName", "")
+
+        # Inline nodes with content (e.g. status)
+        content = node.get("content", [])
+        if content:
+            return self._convert_inline_children(content)
+        return ""
+
+    def _apply_marks(self, text: str, marks: list) -> str:
+        for mark in marks:
+            mtype = mark.get("type", "")
+            if mtype == "strong":
+                text = f"**{text}**"
+            elif mtype == "em":
+                text = f"*{text}*"
+            elif mtype == "code":
+                text = f"`{text}`"
+            elif mtype == "link":
+                href = mark.get("attrs", {}).get("href", "")
+                text = f"[{text}]({href})"
+            elif mtype == "strike":
+                text = f"~~{text}~~"
+        return text
+
+    def _convert_list(self, items: list, ordered: bool, depth: int = 0) -> str:
+        lines = []
+        indent = "  " * depth
+        for i, item in enumerate(items):
+            if item.get("type") != "listItem":
+                continue
+            content = item.get("content", [])
+            # First block is the item text, rest may be nested lists
+            text_parts = []
+            nested = []
+            for child in content:
+                ctype = child.get("type", "")
+                if ctype in ("bulletList", "orderedList"):
+                    nested.append(child)
+                else:
+                    text_parts.append(child)
+
+            item_text = self._convert_children_blocks(text_parts)
+            prefix = f"{i + 1}." if ordered else "-"
+            lines.append(f"{indent}{prefix} {item_text}")
+
+            for nest in nested:
+                is_ordered = nest.get("type") == "orderedList"
+                lines.append(self._convert_list(
+                    nest.get("content", []), ordered=is_ordered, depth=depth + 1
+                ))
+        return "\n".join(lines)
+
+    def _convert_table(self, rows: list) -> str:
+        if not rows:
+            return ""
+
+        md_rows: List[List[str]] = []
+        is_header_row = [False] * len(rows)
+
+        for ri, row in enumerate(rows):
+            if row.get("type") != "tableRow":
+                continue
+            cells = row.get("content", [])
+            md_cells = []
+            has_header = False
+            for cell in cells:
+                ctype = cell.get("type", "")
+                text = self._convert_children_blocks(cell.get("content", []))
+                text = text.replace("\n", " ").strip()
+                md_cells.append(text)
+                if ctype == "tableHeader":
+                    has_header = True
+            md_rows.append(md_cells)
+            is_header_row[ri] = has_header
+
+        if not md_rows:
+            return ""
+
+        # Normalize column count
+        max_cols = max(len(r) for r in md_rows)
+        for row in md_rows:
+            while len(row) < max_cols:
+                row.append("")
+
+        lines = []
+        lines.append("| " + " | ".join(md_rows[0]) + " |")
+        lines.append("| " + " | ".join("---" for _ in range(max_cols)) + " |")
+        for row in md_rows[1:]:
+            lines.append("| " + " | ".join(row) + " |")
+        return "\n".join(lines)
+
+    def _convert_children_blocks(self, nodes: list) -> str:
+        parts = [self._convert_block(n) for n in nodes]
+        return "\n\n".join(p for p in parts if p)
+
+    def _extract_text(self, nodes: list) -> str:
+        """Extract plain text from inline nodes (for code blocks)."""
+        parts = []
+        for node in nodes:
+            if node.get("type") == "text":
+                parts.append(node.get("text", ""))
+            elif node.get("content"):
+                parts.append(self._extract_text(node["content"]))
+        return "".join(parts)
+
+
+class XHTMLConverter:
+    """Converts Confluence XHTML/Storage format to Markdown.
+
+    Uses ``xml.etree.ElementTree`` — no external dependencies.
+    """
+
+    # Confluence macro namespace
+    AC_NS = "http://atlassian.com/content"
+    RI_NS = "http://atlassian.com/resource/identifier"
+
+    def convert(self, xhtml: str) -> str:
+        if not xhtml or not xhtml.strip():
+            return ""
+        # Wrap in root for valid XML; register namespaces
+        wrapped = (
+            f'<root xmlns:ac="{self.AC_NS}" xmlns:ri="{self.RI_NS}">'
+            f"{xhtml}</root>"
+        )
+        try:
+            root = ET.fromstring(wrapped)
+        except ET.ParseError as e:
+            logger.warning("XHTML parse error, falling back to text strip: %s", e)
+            return self._strip_tags(xhtml)
+
+        md = self._walk(root).strip()
+        # Collapse excessive blank lines
+        md = re.sub(r"\n{3,}", "\n\n", md)
+        return md
+
+    def _walk(self, elem: ET.Element) -> str:
+        tag = self._local_tag(elem.tag)
+        return self._convert_element(elem, tag)
+
+    def _convert_element(self, elem: ET.Element, tag: str) -> str:
+        # --- Headings ---
+        if tag in ("h1", "h2", "h3", "h4", "h5", "h6"):
+            level = int(tag[1])
+            text = self._inner_text(elem).strip()
+            return f"\n\n{'#' * level} {text}\n\n"
+
+        # --- Paragraph ---
+        if tag == "p":
+            text = self._inner_text(elem).strip()
+            return f"\n\n{text}\n\n" if text else ""
+
+        # --- Line break ---
+        if tag == "br":
+            return "\n"
+
+        # --- Bold / Italic ---
+        if tag in ("strong", "b"):
+            return f"**{self._inner_text(elem)}**"
+        if tag in ("em", "i"):
+            return f"*{self._inner_text(elem)}*"
+
+        # --- Code ---
+        if tag == "code":
+            return f"`{self._inner_text(elem)}`"
+        if tag == "pre":
+            return f"\n\n```\n{self._inner_text(elem)}\n```\n\n"
+
+        # --- Links ---
+        if tag == "a":
+            href = elem.get("href", "")
+            text = self._inner_text(elem).strip()
+            return f"[{text}]({href})"
+
+        # --- Images ---
+        if tag == "img":
+            src = elem.get("src", "")
+            alt = elem.get("alt", "")
+            return f"![{alt}]({src})"
+
+        # --- Lists ---
+        if tag == "ul":
+            return "\n\n" + self._convert_list(elem, ordered=False) + "\n\n"
+        if tag == "ol":
+            return "\n\n" + self._convert_list(elem, ordered=True) + "\n\n"
+        if tag == "li":
+            return self._inner_text(elem).strip()
+
+        # --- Table ---
+        if tag == "table":
+            return "\n\n" + self._convert_table(elem) + "\n\n"
+
+        # --- Blockquote ---
+        if tag == "blockquote":
+            text = self._inner_text(elem).strip()
+            return "\n\n" + "\n".join(f"> {l}" for l in text.split("\n")) + "\n\n"
+
+        # --- Horizontal rule ---
+        if tag == "hr":
+            return "\n\n---\n\n"
+
+        # --- Confluence structured macro ---
+        if tag == "structured-macro":
+            return self._convert_macro(elem)
+
+        # --- Confluence image ---
+        if tag == "image":
+            return self._convert_ac_image(elem)
+
+        # --- Root / generic container ---
+        return self._children_text(elem)
+
+    def _convert_macro(self, elem: ET.Element) -> str:
+        macro_name = self._get_attr(elem, "name")
+
+        if macro_name == "code":
+            language = ""
+            body = ""
+            for child in elem:
+                ltag = self._local_tag(child.tag)
+                if ltag == "parameter" and self._get_attr(child, "name") == "language":
+                    language = (child.text or "").strip()
+                if ltag == "plain-text-body":
+                    body = (child.text or "").strip()
+            return f"\n\n```{language}\n{body}\n```\n\n"
+
+        if macro_name in ("info", "note", "warning", "tip", "panel"):
+            label = macro_name.capitalize()
+            body = self._macro_rich_body(elem)
+            return f"\n\n> **{label}:** {body}\n\n"
+
+        if macro_name == "expand":
+            title = ""
+            for child in elem:
+                ltag = self._local_tag(child.tag)
+                if ltag == "parameter" and self._get_attr(child, "name") == "title":
+                    title = (child.text or "").strip()
+            body = self._macro_rich_body(elem)
+            title = title or "Details"
+            return f"\n\n**{title}:** {body}\n\n"
+
+        if macro_name == "noformat":
+            for child in elem:
+                if self._local_tag(child.tag) == "plain-text-body":
+                    return f"\n\n```\n{(child.text or '').strip()}\n```\n\n"
+
+        # Unknown macro — try to extract body
+        body = self._macro_rich_body(elem)
+        return body if body else ""
+
+    def _macro_rich_body(self, elem: ET.Element) -> str:
+        for child in elem:
+            if self._local_tag(child.tag) == "rich-text-body":
+                return self._inner_text(child).strip()
+        return ""
+
+    def _convert_ac_image(self, elem: ET.Element) -> str:
+        url = ""
+        for child in elem:
+            ltag = self._local_tag(child.tag)
+            if ltag == "url":
+                url = self._get_attr(child, "value") or child.get("href", "")
+            elif ltag == "attachment":
+                url = self._get_attr(child, "filename") or ""
+        alt = self._get_attr(elem, "alt") or ""
+        return f"![{alt}]({url})"
+
+    def _convert_list(self, elem: ET.Element, ordered: bool) -> str:
+        lines = []
+        for i, child in enumerate(elem):
+            if self._local_tag(child.tag) == "li":
+                text = self._inner_text(child).strip()
+                prefix = f"{i + 1}." if ordered else "-"
+                lines.append(f"{prefix} {text}")
+        return "\n".join(lines)
+
+    def _convert_table(self, elem: ET.Element) -> str:
+        rows: List[List[str]] = []
+
+        for child in elem:
+            ltag = self._local_tag(child.tag)
+            if ltag == "tr":
+                row = self._parse_table_row(child)
+                rows.append(row)
+            elif ltag in ("thead", "tbody", "tfoot"):
+                for sub in child:
+                    if self._local_tag(sub.tag) == "tr":
+                        rows.append(self._parse_table_row(sub))
+
+        if not rows:
+            return ""
+
+        max_cols = max(len(r) for r in rows)
+        for row in rows:
+            while len(row) < max_cols:
+                row.append("")
+
+        lines = []
+        lines.append("| " + " | ".join(rows[0]) + " |")
+        lines.append("| " + " | ".join("---" for _ in range(max_cols)) + " |")
+        for row in rows[1:]:
+            lines.append("| " + " | ".join(row) + " |")
+        return "\n".join(lines)
+
+    def _parse_table_row(self, tr: ET.Element) -> List[str]:
+        cells = []
+        for cell in tr:
+            ltag = self._local_tag(cell.tag)
+            if ltag in ("td", "th"):
+                text = self._inner_text(cell).strip().replace("\n", " ")
+                cells.append(text)
+        return cells
+
+    def _inner_text(self, elem: ET.Element) -> str:
+        """Recursively get text, converting child elements."""
+        parts = []
+        if elem.text:
+            parts.append(elem.text)
+        for child in elem:
+            parts.append(self._walk(child))
+            if child.tail:
+                parts.append(child.tail)
+        return "".join(parts)
+
+    def _children_text(self, elem: ET.Element) -> str:
+        """Like _inner_text but for generic containers."""
+        return self._inner_text(elem)
+
+    @staticmethod
+    def _local_tag(tag: str) -> str:
+        """Strip namespace from tag: ``{ns}local`` → ``local``."""
+        if "}" in tag:
+            return tag.split("}", 1)[1]
+        return tag
+
+    @staticmethod
+    def _get_attr(elem: ET.Element, local_name: str) -> str:
+        """Get attribute by local name, ignoring namespace prefix."""
+        for key, val in elem.attrib.items():
+            attr_local = key.split("}", 1)[-1] if "}" in key else key
+            if attr_local == local_name:
+                return val
+        return ""
+
+    @staticmethod
+    def _strip_tags(html: str) -> str:
+        """Fallback: strip all tags and return text."""
+        return re.sub(r"<[^>]+>", "", html).strip()
+
+
+def convert_content(body: Any, fmt: str) -> str:
+    """Convert Confluence page body to Markdown.
+
+    Args:
+        body: ADF dict or XHTML string.
+        fmt: ``"adf"`` for Cloud atlas_doc_format,
+             ``"storage"`` or ``"xhtml"`` for On-Prem storage format.
+
+    Returns:
+        Markdown string.
+    """
+    if fmt == "adf":
+        if isinstance(body, dict):
+            return ADFConverter().convert(body)
+        return ""
+    if fmt in ("storage", "xhtml"):
+        if isinstance(body, str):
+            return XHTMLConverter().convert(body)
+        return ""
+    logger.warning("Unknown content format: %s", fmt)
+    return str(body) if body else ""

--- a/src/atlassian/factory.py
+++ b/src/atlassian/factory.py
@@ -1,0 +1,83 @@
+"""Factory for creating Atlassian auth providers and HTTP clients"""
+
+import logging
+from typing import Dict, Type
+
+from .auth.base_auth import AtlassianAuthProvider
+from .auth.basic_auth import BasicAuthProvider
+from .auth.pat_auth import PATAuthProvider
+from .auth.oauth2_auth import OAuth2AuthProvider
+from .base import AuthMethod, AtlassianConfigError
+from .config import ConfluenceConfig
+from .http_client import AtlassianHTTPClient
+
+logger = logging.getLogger(__name__)
+
+
+class AtlassianAuthFactory:
+    """Registry-based factory for auth providers and convenience HTTP client creation.
+
+    Follows the pattern from ``src/ai_providers/factory.py``.
+    """
+
+    _auth_providers: Dict[AuthMethod, Type[AtlassianAuthProvider]] = {}
+
+    @classmethod
+    def register_auth_provider(
+        cls,
+        method: AuthMethod,
+        provider_class: Type[AtlassianAuthProvider],
+    ) -> None:
+        if not issubclass(provider_class, AtlassianAuthProvider):
+            raise ValueError("provider_class must be a subclass of AtlassianAuthProvider")
+        cls._auth_providers[method] = provider_class
+        logger.info("Registered Atlassian auth provider: %s", method.value)
+
+    @classmethod
+    def create_auth_provider(cls, config: ConfluenceConfig) -> AtlassianAuthProvider:
+        """Create the appropriate auth provider from a ``ConfluenceConfig``."""
+        provider_cls = cls._auth_providers.get(config.auth_method)
+        if provider_cls is None:
+            available = [m.value for m in cls._auth_providers]
+            raise AtlassianConfigError(
+                f"No auth provider registered for method '{config.auth_method.value}'. "
+                f"Available: {available}"
+            )
+        return provider_cls(config.auth_config)
+
+    @classmethod
+    def create_http_client(cls, config: ConfluenceConfig) -> AtlassianHTTPClient:
+        """Convenience: config → auth provider → HTTP client."""
+        auth = cls.create_auth_provider(config)
+        return AtlassianHTTPClient(
+            auth_provider=auth,
+            base_url=config.base_url,
+            timeout=config.timeout,
+            connect_timeout=config.connect_timeout,
+            pool_size=config.pool_size,
+            max_retries=config.max_retries,
+            ssl_verify=config.ssl_verify,
+            ca_bundle=config.ca_bundle,
+        )
+
+    @classmethod
+    def list_registered(cls) -> list:
+        return [m.value for m in cls._auth_providers]
+
+    @classmethod
+    def clear_registry(cls) -> None:
+        cls._auth_providers.clear()
+
+
+def _register_providers() -> None:
+    """Register built-in auth providers at module import time."""
+    AtlassianAuthFactory.register_auth_provider(AuthMethod.BASIC, BasicAuthProvider)
+    AtlassianAuthFactory.register_auth_provider(AuthMethod.PAT, PATAuthProvider)
+    AtlassianAuthFactory.register_auth_provider(AuthMethod.OAUTH2, OAuth2AuthProvider)
+    logger.info(
+        "Atlassian auth provider registration complete. Available: %s",
+        AtlassianAuthFactory.list_registered(),
+    )
+
+
+_register_providers()

--- a/src/atlassian/http_client.py
+++ b/src/atlassian/http_client.py
@@ -1,0 +1,229 @@
+"""HTTP client for Atlassian APIs with retry, rate-limit, and auth injection"""
+
+import asyncio
+import logging
+import ssl
+import time
+from typing import Any, Dict, Optional
+
+import aiohttp
+from aiohttp import ClientSession, ClientTimeout, TCPConnector
+
+from .auth.base_auth import AtlassianAuthProvider
+from .base import (
+    AtlassianAPIError,
+    AtlassianAuthError,
+    AtlassianRateLimitError,
+)
+
+logger = logging.getLogger(__name__)
+
+RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
+
+
+class AtlassianHTTPClient:
+    """Async HTTP client that injects auth headers and handles retries.
+
+    Follows aiohttp patterns from ``src/ai_providers/providers/ollama_provider.py``.
+    """
+
+    def __init__(
+        self,
+        auth_provider: AtlassianAuthProvider,
+        base_url: str,
+        *,
+        timeout: float = 30.0,
+        connect_timeout: float = 10.0,
+        pool_size: int = 10,
+        max_retries: int = 3,
+        ssl_verify: bool = True,
+        ca_bundle: Optional[str] = None,
+    ):
+        self.auth_provider = auth_provider
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self.connect_timeout = connect_timeout
+        self.pool_size = pool_size
+        self.max_retries = max_retries
+        self.ssl_verify = ssl_verify
+        self.ca_bundle = ca_bundle
+
+        self._session: Optional[ClientSession] = None
+        self._ssl_context: Optional[ssl.SSLContext] = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def initialize(self) -> None:
+        """Create the ``aiohttp.ClientSession`` and SSL context."""
+        self._ssl_context = self._build_ssl_context()
+        connector = TCPConnector(
+            limit=self.pool_size,
+            ssl=self._ssl_context,
+        )
+        client_timeout = ClientTimeout(
+            total=self.timeout,
+            connect=self.connect_timeout,
+        )
+        self._session = ClientSession(
+            timeout=client_timeout,
+            connector=connector,
+        )
+        await self.auth_provider.initialize()
+        logger.info("AtlassianHTTPClient initialized (base_url=%s)", self.base_url)
+
+    async def close(self) -> None:
+        """Close session and auth provider."""
+        if self._session:
+            await self._session.close()
+            self._session = None
+        await self.auth_provider.close()
+        logger.info("AtlassianHTTPClient closed")
+
+    # ------------------------------------------------------------------
+    # Public request API
+    # ------------------------------------------------------------------
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        json: Optional[Any] = None,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
+        """Send an authenticated request with retry logic.
+
+        Args:
+            method: HTTP method (GET, POST, …).
+            path: API path appended to ``base_url``.
+            params: Query parameters.
+            json: JSON body.
+            headers: Extra headers (merged with auth headers).
+
+        Returns:
+            Parsed JSON response body.
+
+        Raises:
+            AtlassianAuthError: On 401 after one retry with refreshed token.
+            AtlassianRateLimitError: On 429 after retries exhausted.
+            AtlassianAPIError: On other non-recoverable HTTP errors.
+        """
+        if not self._session:
+            raise RuntimeError("Client not initialized. Call initialize() first.")
+
+        url = f"{self.base_url}{path}"
+        retry_delay = 1.0
+        auth_retried = False
+
+        for attempt in range(self.max_retries + 1):
+            auth = await self.auth_provider.get_auth_headers()
+            merged_headers = {**auth.headers, **(headers or {})}
+
+            self._log_request(method, url, attempt)
+
+            try:
+                async with self._session.request(
+                    method, url, params=params, json=json, headers=merged_headers
+                ) as resp:
+                    status = resp.status
+
+                    if 200 <= status < 300:
+                        if resp.content_type and "json" in resp.content_type:
+                            return await resp.json()
+                        text = await resp.text()
+                        return {"_raw": text}
+
+                    body = await resp.text()
+
+                    # 401 — force refresh once then retry
+                    if status == 401 and not auth_retried:
+                        auth_retried = True
+                        logger.warning("Got 401, forcing token refresh and retrying")
+                        await self.auth_provider.refresh_if_needed()
+                        continue
+
+                    if status == 401:
+                        raise AtlassianAuthError(
+                            f"Authentication failed after refresh (HTTP 401): {body[:300]}"
+                        )
+
+                    # 429 — respect Retry-After
+                    if status == 429:
+                        retry_after = self._parse_retry_after(resp)
+                        if attempt < self.max_retries:
+                            wait = retry_after or retry_delay
+                            logger.warning(
+                                "Rate limited (429). Waiting %.1fs (attempt %d/%d)",
+                                wait, attempt + 1, self.max_retries + 1,
+                            )
+                            await asyncio.sleep(wait)
+                            retry_delay = min(retry_delay * 2, 60.0)
+                            continue
+                        raise AtlassianRateLimitError(
+                            f"Rate limit exceeded after {self.max_retries + 1} attempts",
+                            retry_after=retry_after,
+                            status_code=429,
+                            response_body=body[:500],
+                        )
+
+                    # Retryable server errors
+                    if status in RETRYABLE_STATUS_CODES and attempt < self.max_retries:
+                        logger.warning(
+                            "Retryable error %d on %s (attempt %d/%d). Retrying in %.1fs",
+                            status, path, attempt + 1, self.max_retries + 1, retry_delay,
+                        )
+                        await asyncio.sleep(retry_delay)
+                        retry_delay = min(retry_delay * 2, 60.0)
+                        continue
+
+                    raise AtlassianAPIError(
+                        f"HTTP {status}: {body[:500]}",
+                        status_code=status,
+                        response_body=body[:1000],
+                    )
+
+            except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+                if attempt < self.max_retries:
+                    logger.warning(
+                        "Connection error on %s (attempt %d/%d): %s. Retrying in %.1fs",
+                        path, attempt + 1, self.max_retries + 1, e, retry_delay,
+                    )
+                    await asyncio.sleep(retry_delay)
+                    retry_delay = min(retry_delay * 2, 60.0)
+                    continue
+                raise AtlassianAPIError(f"Connection failed after retries: {e}") from e
+
+        # Should not reach here, but just in case
+        raise AtlassianAPIError("Request failed after all retries")
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _build_ssl_context(self) -> Optional[ssl.SSLContext]:
+        if not self.ssl_verify:
+            ctx = ssl.create_default_context()
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+            return ctx
+        if self.ca_bundle:
+            ctx = ssl.create_default_context(cafile=self.ca_bundle)
+            return ctx
+        return None  # aiohttp uses default system certs
+
+    @staticmethod
+    def _parse_retry_after(resp: aiohttp.ClientResponse) -> Optional[float]:
+        raw = resp.headers.get("Retry-After")
+        if raw is None:
+            return None
+        try:
+            return float(raw)
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _log_request(method: str, url: str, attempt: int) -> None:
+        logger.debug("→ %s %s (attempt %d)", method, url, attempt + 1)

--- a/tests/test_atlassian/test_base.py
+++ b/tests/test_atlassian/test_base.py
@@ -1,0 +1,85 @@
+"""Tests for src/atlassian/base.py — enums, dataclasses, exceptions"""
+
+import pytest
+
+from src.atlassian.base import (
+    AuthHeaders,
+    AuthHealthStatus,
+    AuthMethod,
+    AtlassianAPIError,
+    AtlassianAuthError,
+    AtlassianConfigError,
+    AtlassianError,
+    AtlassianRateLimitError,
+    DeploymentType,
+)
+
+
+class TestEnums:
+    def test_deployment_type_values(self):
+        assert DeploymentType.CLOUD.value == "cloud"
+        assert DeploymentType.ON_PREM.value == "on_prem"
+        assert DeploymentType.DATA_CENTER.value == "data_center"
+
+    def test_auth_method_values(self):
+        assert AuthMethod.BASIC.value == "basic"
+        assert AuthMethod.PAT.value == "pat"
+        assert AuthMethod.OAUTH2.value == "oauth2"
+
+
+class TestAuthHeaders:
+    def test_creation(self):
+        ah = AuthHeaders(
+            headers={"Authorization": "Basic abc"},
+            auth_method=AuthMethod.BASIC,
+        )
+        assert ah.headers["Authorization"] == "Basic abc"
+        assert ah.auth_method == AuthMethod.BASIC
+        assert ah.expires_at is None
+
+    def test_with_expiry(self):
+        ah = AuthHeaders(
+            headers={}, auth_method=AuthMethod.OAUTH2, expires_at=99999.0
+        )
+        assert ah.expires_at == 99999.0
+
+
+class TestAuthHealthStatus:
+    def test_healthy(self):
+        s = AuthHealthStatus(
+            is_healthy=True,
+            auth_method="basic",
+            deployment_type="cloud",
+            response_time_ms=42.0,
+        )
+        assert s.is_healthy
+        assert s.error_message is None
+
+    def test_unhealthy(self):
+        s = AuthHealthStatus(
+            is_healthy=False,
+            auth_method="pat",
+            deployment_type="on_prem",
+            response_time_ms=100.0,
+            error_message="timeout",
+        )
+        assert not s.is_healthy
+        assert s.error_message == "timeout"
+
+
+class TestExceptions:
+    def test_hierarchy(self):
+        assert issubclass(AtlassianAuthError, AtlassianError)
+        assert issubclass(AtlassianConfigError, AtlassianError)
+        assert issubclass(AtlassianAPIError, AtlassianError)
+        assert issubclass(AtlassianRateLimitError, AtlassianAPIError)
+
+    def test_api_error_attrs(self):
+        e = AtlassianAPIError("fail", status_code=500, response_body="err")
+        assert e.status_code == 500
+        assert e.response_body == "err"
+
+    def test_rate_limit_attrs(self):
+        e = AtlassianRateLimitError("slow", retry_after=30.0, status_code=429)
+        assert e.retry_after == 30.0
+        assert e.status_code == 429

--- a/tests/test_atlassian/test_basic_auth.py
+++ b/tests/test_atlassian/test_basic_auth.py
@@ -1,0 +1,91 @@
+"""Tests for BasicAuthProvider"""
+
+import base64
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from src.atlassian.auth.basic_auth import BasicAuthProvider
+from src.atlassian.base import AuthMethod, AtlassianConfigError
+
+
+def _config(overrides=None):
+    cfg = {
+        "username": "user@example.com",
+        "api_token": "my-api-token",
+        "base_url": "https://myorg.atlassian.net",
+    }
+    if overrides:
+        cfg.update(overrides)
+    return cfg
+
+
+class TestValidation:
+    def test_valid(self):
+        p = BasicAuthProvider(_config())
+        assert p.username == "user@example.com"
+
+    def test_missing_username(self):
+        with pytest.raises(AtlassianConfigError, match="username"):
+            BasicAuthProvider(_config({"username": ""}))
+
+    def test_missing_api_token(self):
+        with pytest.raises(AtlassianConfigError, match="api_token"):
+            BasicAuthProvider(_config({"api_token": ""}))
+
+    def test_missing_base_url(self):
+        with pytest.raises(AtlassianConfigError, match="base_url"):
+            BasicAuthProvider(_config({"base_url": ""}))
+
+
+class TestHeaders:
+    @pytest.mark.asyncio
+    async def test_auth_header_format(self):
+        p = BasicAuthProvider(_config())
+        auth = await p.get_auth_headers()
+        expected = base64.b64encode(b"user@example.com:my-api-token").decode()
+        assert auth.headers["Authorization"] == f"Basic {expected}"
+        assert auth.auth_method == AuthMethod.BASIC
+
+    @pytest.mark.asyncio
+    async def test_token_always_valid(self):
+        p = BasicAuthProvider(_config())
+        assert await p.is_token_valid() is True
+
+
+class TestHealthCheck:
+    @pytest.mark.asyncio
+    async def test_healthy(self):
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("src.atlassian.auth.basic_auth.aiohttp.ClientSession", return_value=mock_session):
+            p = BasicAuthProvider(_config())
+            health = await p.health_check()
+            assert health.is_healthy
+            assert health.auth_method == "basic"
+
+    @pytest.mark.asyncio
+    async def test_unhealthy(self):
+        mock_resp = AsyncMock()
+        mock_resp.status = 401
+        mock_resp.text = AsyncMock(return_value="Unauthorized")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("src.atlassian.auth.basic_auth.aiohttp.ClientSession", return_value=mock_session):
+            p = BasicAuthProvider(_config())
+            health = await p.health_check()
+            assert not health.is_healthy
+            assert "401" in health.error_message

--- a/tests/test_atlassian/test_config.py
+++ b/tests/test_atlassian/test_config.py
@@ -1,0 +1,120 @@
+"""Tests for src/atlassian/config.py — ConfluenceConfig.from_env()"""
+
+import os
+import pytest
+
+from src.atlassian.base import AuthMethod, DeploymentType, AtlassianConfigError
+from src.atlassian.config import ConfluenceConfig
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Remove all CONFLUENCE_* env vars before each test."""
+    for key in list(os.environ):
+        if key.startswith("CONFLUENCE_"):
+            monkeypatch.delenv(key, raising=False)
+
+
+class TestDeploymentDetection:
+    def test_cloud_auto_detect(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_URL", "https://myorg.atlassian.net")
+        monkeypatch.setenv("CONFLUENCE_USERNAME", "user@example.com")
+        monkeypatch.setenv("CONFLUENCE_API_TOKEN", "tok")
+        cfg = ConfluenceConfig.from_env()
+        assert cfg.deployment_type == DeploymentType.CLOUD
+
+    def test_on_prem_auto_detect(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_URL", "https://confluence.corp.local")
+        monkeypatch.setenv("CONFLUENCE_PAT", "mypat")
+        cfg = ConfluenceConfig.from_env()
+        assert cfg.deployment_type == DeploymentType.ON_PREM
+
+    def test_explicit_deployment_type(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_URL", "https://myorg.atlassian.net")
+        monkeypatch.setenv("CONFLUENCE_DEPLOYMENT_TYPE", "data_center")
+        monkeypatch.setenv("CONFLUENCE_PAT", "tok")
+        cfg = ConfluenceConfig.from_env()
+        assert cfg.deployment_type == DeploymentType.DATA_CENTER
+
+    def test_invalid_deployment_type(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_URL", "https://x.atlassian.net")
+        monkeypatch.setenv("CONFLUENCE_DEPLOYMENT_TYPE", "invalid")
+        with pytest.raises(AtlassianConfigError, match="Invalid CONFLUENCE_DEPLOYMENT_TYPE"):
+            ConfluenceConfig.from_env()
+
+
+class TestAuthMethodDetection:
+    def test_basic_auth(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_URL", "https://x.atlassian.net")
+        monkeypatch.setenv("CONFLUENCE_USERNAME", "u")
+        monkeypatch.setenv("CONFLUENCE_API_TOKEN", "t")
+        cfg = ConfluenceConfig.from_env()
+        assert cfg.auth_method == AuthMethod.BASIC
+
+    def test_pat_auth(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_URL", "https://confluence.corp.local")
+        monkeypatch.setenv("CONFLUENCE_PAT", "mypat")
+        cfg = ConfluenceConfig.from_env()
+        assert cfg.auth_method == AuthMethod.PAT
+
+    def test_oauth2_auth(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_URL", "https://x.atlassian.net")
+        monkeypatch.setenv("CONFLUENCE_OAUTH2_CLIENT_ID", "cid")
+        monkeypatch.setenv("CONFLUENCE_OAUTH2_CLIENT_SECRET", "sec")
+        monkeypatch.setenv("CONFLUENCE_OAUTH2_ACCESS_TOKEN", "at")
+        cfg = ConfluenceConfig.from_env()
+        assert cfg.auth_method == AuthMethod.OAUTH2
+
+    def test_explicit_auth_method(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_URL", "https://x.atlassian.net")
+        monkeypatch.setenv("CONFLUENCE_AUTH_METHOD", "pat")
+        monkeypatch.setenv("CONFLUENCE_PAT", "mypat")
+        cfg = ConfluenceConfig.from_env()
+        assert cfg.auth_method == AuthMethod.PAT
+
+    def test_no_credentials_raises(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_URL", "https://x.atlassian.net")
+        with pytest.raises(AtlassianConfigError, match="Cannot auto-detect"):
+            ConfluenceConfig.from_env()
+
+
+class TestValidation:
+    def test_missing_url(self, monkeypatch):
+        with pytest.raises(AtlassianConfigError, match="CONFLUENCE_URL is required"):
+            ConfluenceConfig.from_env()
+
+    def test_invalid_url_scheme(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_URL", "ftp://bad")
+        with pytest.raises(AtlassianConfigError, match="must start with http"):
+            ConfluenceConfig.from_env()
+
+    def test_oauth2_on_prem_rejected(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_URL", "https://confluence.corp.local")
+        monkeypatch.setenv("CONFLUENCE_AUTH_METHOD", "oauth2")
+        monkeypatch.setenv("CONFLUENCE_OAUTH2_CLIENT_ID", "cid")
+        monkeypatch.setenv("CONFLUENCE_OAUTH2_CLIENT_SECRET", "sec")
+        monkeypatch.setenv("CONFLUENCE_OAUTH2_ACCESS_TOKEN", "at")
+        with pytest.raises(AtlassianConfigError, match="OAuth2 is only supported"):
+            ConfluenceConfig.from_env()
+
+    def test_basic_missing_username(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_URL", "https://x.atlassian.net")
+        monkeypatch.setenv("CONFLUENCE_AUTH_METHOD", "basic")
+        monkeypatch.setenv("CONFLUENCE_API_TOKEN", "tok")
+        with pytest.raises(AtlassianConfigError, match="CONFLUENCE_USERNAME"):
+            ConfluenceConfig.from_env()
+
+    def test_ca_bundle_not_found(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_URL", "https://x.atlassian.net")
+        monkeypatch.setenv("CONFLUENCE_USERNAME", "u")
+        monkeypatch.setenv("CONFLUENCE_API_TOKEN", "t")
+        monkeypatch.setenv("CONFLUENCE_CA_BUNDLE", "/nonexistent/cert.pem")
+        with pytest.raises(AtlassianConfigError, match="CA bundle file not found"):
+            ConfluenceConfig.from_env()
+
+    def test_url_trailing_slash_stripped(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_URL", "https://x.atlassian.net/")
+        monkeypatch.setenv("CONFLUENCE_USERNAME", "u")
+        monkeypatch.setenv("CONFLUENCE_API_TOKEN", "t")
+        cfg = ConfluenceConfig.from_env()
+        assert not cfg.base_url.endswith("/")

--- a/tests/test_atlassian/test_confluence_crawler.py
+++ b/tests/test_atlassian/test_confluence_crawler.py
@@ -1,0 +1,457 @@
+"""Tests for ConfluenceCrawler — mocked at client.request() level"""
+
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.atlassian.base import AtlassianAPIError, DeploymentType
+from src.atlassian.confluence_crawler import (
+    ConfluenceCrawler,
+    ConfluencePage,
+    CrawlResult,
+    CrawlSummary,
+)
+
+
+# ------------------------------------------------------------------
+# Fixtures / helpers
+# ------------------------------------------------------------------
+
+def _cloud_page_response(page_id="123", title="Test Page", space_key="DEV"):
+    """Minimal Cloud v2 page response."""
+    return {
+        "id": page_id,
+        "title": title,
+        "spaceId": "space-1",
+        "space": {"key": space_key},
+        "parentId": "100",
+        "createdAt": "2025-01-01T00:00:00Z",
+        "body": {
+            "atlas_doc_format": {
+                "value": json.dumps({
+                    "type": "doc",
+                    "content": [
+                        {"type": "paragraph", "content": [
+                            {"type": "text", "text": "Hello from Cloud"}
+                        ]}
+                    ],
+                })
+            }
+        },
+        "version": {
+            "by": {"displayName": "Alice"},
+            "createdAt": "2025-01-02T00:00:00Z",
+        },
+        "labels": {"results": [{"name": "docs"}, {"name": "v2"}]},
+        "_links": {"base": "https://acme.atlassian.net/wiki", "webui": "/spaces/DEV/pages/123"},
+    }
+
+
+def _onprem_page_response(page_id="456", title="On-Prem Page", space_key="ENG"):
+    """Minimal On-Prem v1 content response."""
+    return {
+        "id": page_id,
+        "title": title,
+        "space": {"key": space_key},
+        "body": {
+            "storage": {
+                "value": "<p>Hello from On-Prem</p>",
+            }
+        },
+        "version": {
+            "by": {"displayName": "Bob"},
+            "when": "2025-03-01T00:00:00Z",
+        },
+        "metadata": {
+            "labels": {"results": [{"name": "internal"}]},
+        },
+        "ancestors": [{"id": "10"}, {"id": "50"}],
+        "_links": {"base": "https://confluence.corp.com", "webui": "/display/ENG/On-Prem+Page"},
+    }
+
+
+def _make_crawler(deployment_type=DeploymentType.CLOUD, max_pages=100, max_depth=5):
+    client = AsyncMock()
+    crawler = ConfluenceCrawler(client, deployment_type)
+    crawler.max_pages = max_pages
+    crawler.max_depth = max_depth
+    return crawler, client
+
+
+# ------------------------------------------------------------------
+# Single page crawl
+# ------------------------------------------------------------------
+
+class TestCrawlPageCloud:
+    @pytest.mark.asyncio
+    async def test_crawl_page_cloud(self):
+        crawler, client = _make_crawler(DeploymentType.CLOUD)
+        client.request.return_value = _cloud_page_response()
+
+        page = await crawler.crawl_page("123")
+
+        assert isinstance(page, ConfluencePage)
+        assert page.page_id == "123"
+        assert page.title == "Test Page"
+        assert page.space_key == "DEV"
+        assert "Hello from Cloud" in page.markdown_content
+        assert page.author == "Alice"
+        assert page.labels == ["docs", "v2"]
+        assert page.parent_page_id == "100"
+        assert "atlassian.net" in page.url
+
+        client.request.assert_called_once_with(
+            "GET",
+            "/wiki/api/v2/pages/123",
+            params={"body-format": "atlas_doc_format"},
+        )
+
+
+class TestCrawlPageOnPrem:
+    @pytest.mark.asyncio
+    async def test_crawl_page_onprem(self):
+        crawler, client = _make_crawler(DeploymentType.ON_PREM)
+        client.request.return_value = _onprem_page_response()
+
+        page = await crawler.crawl_page("456")
+
+        assert page.page_id == "456"
+        assert page.title == "On-Prem Page"
+        assert page.space_key == "ENG"
+        assert "Hello from On-Prem" in page.markdown_content
+        assert page.author == "Bob"
+        assert page.labels == ["internal"]
+        assert page.parent_page_id == "50"  # last ancestor
+
+        client.request.assert_called_once_with(
+            "GET",
+            "/rest/api/content/456",
+            params={"expand": "body.storage,metadata.labels,ancestors,version,space"},
+        )
+
+
+# ------------------------------------------------------------------
+# Crawl page by URL
+# ------------------------------------------------------------------
+
+class TestCrawlPageByURL:
+    @pytest.mark.asyncio
+    async def test_cloud_url(self):
+        crawler, client = _make_crawler(DeploymentType.CLOUD)
+        client.request.return_value = _cloud_page_response()
+
+        page = await crawler.crawl_page_by_url(
+            "https://acme.atlassian.net/wiki/spaces/DEV/pages/123/Test-Page"
+        )
+        assert page.page_id == "123"
+
+    @pytest.mark.asyncio
+    async def test_onprem_viewpage_url(self):
+        crawler, client = _make_crawler(DeploymentType.ON_PREM)
+        client.request.return_value = _onprem_page_response()
+
+        page = await crawler.crawl_page_by_url(
+            "https://confluence.corp.com/pages/viewpage.action?pageId=456"
+        )
+        assert page.page_id == "456"
+
+    @pytest.mark.asyncio
+    async def test_invalid_url_raises(self):
+        crawler, client = _make_crawler()
+        with pytest.raises(ValueError, match="Cannot extract page ID"):
+            await crawler.crawl_page_by_url("https://example.com/no-page-id-here")
+
+
+# ------------------------------------------------------------------
+# Space crawl
+# ------------------------------------------------------------------
+
+class TestCrawlSpaceCloud:
+    @pytest.mark.asyncio
+    async def test_crawl_space_single_page(self):
+        crawler, client = _make_crawler(DeploymentType.CLOUD)
+
+        async def mock_request(method, path, **kwargs):
+            if "/v2/spaces" == path.rstrip("/") or path == "/wiki/api/v2/spaces":
+                return {"results": [{"id": "space-1", "key": "DEV"}]}
+            if "space-1/pages" in path:
+                return {
+                    "results": [{"id": "123"}],
+                    "_links": {},
+                }
+            # Page fetch
+            return _cloud_page_response()
+
+        client.request.side_effect = mock_request
+        result = await crawler.crawl_space("DEV")
+
+        assert isinstance(result, CrawlResult)
+        assert result.space_key == "DEV"
+        assert result.summary.pages_succeeded == 1
+        assert result.summary.pages_failed == 0
+        assert len(result.pages) == 1
+
+    @pytest.mark.asyncio
+    async def test_crawl_space_cursor_pagination(self):
+        crawler, client = _make_crawler(DeploymentType.CLOUD)
+
+        call_count = 0
+
+        async def mock_request(method, path, **kwargs):
+            nonlocal call_count
+            if "/v2/spaces" == path.rstrip("/") or path == "/wiki/api/v2/spaces":
+                return {"results": [{"id": "space-1", "key": "DEV"}]}
+            if "space-1/pages" in path:
+                call_count += 1
+                if call_count == 1:
+                    return {
+                        "results": [{"id": "1"}],
+                        "_links": {"next": "/wiki/api/v2/spaces/space-1/pages?cursor=abc123"},
+                    }
+                return {
+                    "results": [{"id": "2"}],
+                    "_links": {},
+                }
+            return _cloud_page_response(page_id=path.split("/")[-1])
+
+        client.request.side_effect = mock_request
+        result = await crawler.crawl_space("DEV")
+        assert result.summary.pages_succeeded == 2
+
+
+class TestCrawlSpaceOnPrem:
+    @pytest.mark.asyncio
+    async def test_crawl_space_offset_pagination(self):
+        crawler, client = _make_crawler(DeploymentType.ON_PREM)
+
+        call_count = 0
+
+        async def mock_request(method, path, **kwargs):
+            nonlocal call_count
+            params = kwargs.get("params", {})
+            if path == "/rest/api/content" and params.get("type") == "page":
+                call_count += 1
+                if call_count == 1:
+                    # Return size == limit to trigger next page
+                    return {
+                        "results": [{"id": str(i)} for i in range(10, 35)],
+                        "size": 25,
+                    }
+                # Second call — fewer than limit means last page
+                return {
+                    "results": [{"id": "35"}],
+                    "size": 1,
+                }
+            return _onprem_page_response(page_id=path.split("/")[-1])
+
+        client.request.side_effect = mock_request
+        result = await crawler.crawl_space("ENG")
+        assert result.summary.pages_succeeded == 26
+        assert call_count == 2  # two pagination requests
+
+
+# ------------------------------------------------------------------
+# Page tree crawl
+# ------------------------------------------------------------------
+
+class TestCrawlPageTree:
+    @pytest.mark.asyncio
+    async def test_bfs_traversal(self):
+        crawler, client = _make_crawler(DeploymentType.CLOUD, max_depth=2)
+
+        async def mock_request(method, path, **kwargs):
+            # Page fetch
+            if "/wiki/api/v2/pages/" in path and "/children" not in path:
+                pid = path.split("/")[-1]
+                return _cloud_page_response(page_id=pid, title=f"Page {pid}")
+            # Children
+            if "/children" in path:
+                pid = path.split("/")[-2]
+                if pid == "1":
+                    return {"results": [{"id": "2"}, {"id": "3"}]}
+                if pid == "2":
+                    return {"results": [{"id": "4"}]}
+                return {"results": []}
+            return {}
+
+        client.request.side_effect = mock_request
+        result = await crawler.crawl_page_tree("1")
+
+        crawled_ids = {p.page_id for p in result.pages}
+        assert "1" in crawled_ids
+        assert "2" in crawled_ids
+        assert "3" in crawled_ids
+        assert "4" in crawled_ids
+        assert result.summary.pages_succeeded == 4
+
+    @pytest.mark.asyncio
+    async def test_cycle_detection(self):
+        """Cycles in the page tree should not cause infinite loops."""
+        crawler, client = _make_crawler(DeploymentType.CLOUD, max_depth=5)
+
+        async def mock_request(method, path, **kwargs):
+            if "/children" in path:
+                pid = path.split("/")[-2]
+                if pid == "1":
+                    return {"results": [{"id": "2"}]}
+                if pid == "2":
+                    return {"results": [{"id": "1"}]}  # cycle!
+                return {"results": []}
+            pid = path.split("/")[-1]
+            return _cloud_page_response(page_id=pid)
+
+        client.request.side_effect = mock_request
+        result = await crawler.crawl_page_tree("1")
+
+        assert result.summary.pages_succeeded == 2  # only 1 and 2
+        assert len(result.pages) == 2
+
+    @pytest.mark.asyncio
+    async def test_max_depth_limit(self):
+        crawler, client = _make_crawler(DeploymentType.CLOUD, max_depth=1)
+
+        async def mock_request(method, path, **kwargs):
+            if "/children" in path:
+                pid = path.split("/")[-2]
+                if pid == "1":
+                    return {"results": [{"id": "2"}]}
+                if pid == "2":
+                    return {"results": [{"id": "3"}]}
+                return {"results": []}
+            pid = path.split("/")[-1]
+            return _cloud_page_response(page_id=pid)
+
+        client.request.side_effect = mock_request
+        result = await crawler.crawl_page_tree("1")
+
+        crawled_ids = {p.page_id for p in result.pages}
+        assert "1" in crawled_ids
+        assert "2" in crawled_ids
+        assert "3" not in crawled_ids  # beyond max_depth=1
+
+    @pytest.mark.asyncio
+    async def test_max_pages_limit(self):
+        crawler, client = _make_crawler(DeploymentType.CLOUD, max_pages=2, max_depth=5)
+
+        async def mock_request(method, path, **kwargs):
+            if "/children" in path:
+                return {"results": [{"id": "99"}]}
+            pid = path.split("/")[-1]
+            return _cloud_page_response(page_id=pid)
+
+        client.request.side_effect = mock_request
+        result = await crawler.crawl_page_tree("1")
+
+        assert result.summary.pages_succeeded <= 2
+
+
+# ------------------------------------------------------------------
+# Error handling
+# ------------------------------------------------------------------
+
+class TestErrorHandling:
+    @pytest.mark.asyncio
+    async def test_403_skipped(self):
+        crawler, client = _make_crawler(DeploymentType.CLOUD)
+
+        async def mock_request(method, path, **kwargs):
+            if "forbidden" in path or path.endswith("/2"):
+                raise AtlassianAPIError("Forbidden", status_code=403)
+            pid = path.split("/")[-1]
+            return _cloud_page_response(page_id=pid)
+
+        client.request.side_effect = mock_request
+        result = CrawlResult()
+        page = await crawler._safe_crawl_page("2", result)
+
+        assert page is None
+        assert result.summary.pages_failed == 1
+        assert len(result.summary.errors) == 1
+
+    @pytest.mark.asyncio
+    async def test_404_skipped(self):
+        crawler, client = _make_crawler(DeploymentType.CLOUD)
+        client.request.side_effect = AtlassianAPIError("Not Found", status_code=404)
+
+        result = CrawlResult()
+        page = await crawler._safe_crawl_page("999", result)
+
+        assert page is None
+        assert result.summary.pages_failed == 1
+
+    @pytest.mark.asyncio
+    async def test_500_recorded_as_error(self):
+        crawler, client = _make_crawler(DeploymentType.CLOUD)
+        client.request.side_effect = AtlassianAPIError("Server Error", status_code=500)
+
+        result = CrawlResult()
+        page = await crawler._safe_crawl_page("500", result)
+
+        assert page is None
+        assert result.summary.pages_failed == 1
+        assert "Server Error" in result.summary.errors[0]["error"]
+
+
+# ------------------------------------------------------------------
+# URL parsing
+# ------------------------------------------------------------------
+
+class TestURLParsing:
+    def test_cloud_page_url(self):
+        crawler, _ = _make_crawler()
+        pid = crawler._parse_page_id_from_url(
+            "https://acme.atlassian.net/wiki/spaces/DEV/pages/12345/My-Page"
+        )
+        assert pid == "12345"
+
+    def test_onprem_viewpage_url(self):
+        crawler, _ = _make_crawler()
+        pid = crawler._parse_page_id_from_url(
+            "https://confluence.corp.com/pages/viewpage.action?pageId=67890"
+        )
+        assert pid == "67890"
+
+    def test_rest_api_url(self):
+        crawler, _ = _make_crawler()
+        pid = crawler._parse_page_id_from_url(
+            "https://confluence.corp.com/rest/api/content/111"
+        )
+        assert pid == "111"
+
+    def test_v2_api_url(self):
+        crawler, _ = _make_crawler()
+        pid = crawler._parse_page_id_from_url(
+            "https://acme.atlassian.net/wiki/api/v2/pages/222"
+        )
+        assert pid == "222"
+
+    def test_unparseable_url_raises(self):
+        crawler, _ = _make_crawler()
+        with pytest.raises(ValueError):
+            crawler._parse_page_id_from_url("https://example.com/random/path")
+
+
+# ------------------------------------------------------------------
+# Dataclass basic tests
+# ------------------------------------------------------------------
+
+class TestDataclasses:
+    def test_confluence_page_defaults(self):
+        page = ConfluencePage(
+            page_id="1", title="T", space_key="S", url="u", markdown_content="m"
+        )
+        assert page.labels == []
+        assert page.metadata == {}
+        assert page.parent_page_id is None
+
+    def test_crawl_summary_defaults(self):
+        s = CrawlSummary()
+        assert s.pages_succeeded == 0
+        assert s.pages_failed == 0
+        assert s.page_ids_crawled == set()
+        assert s.errors == []
+
+    def test_crawl_result_defaults(self):
+        r = CrawlResult()
+        assert r.pages == []
+        assert r.space_key is None

--- a/tests/test_atlassian/test_content_converter.py
+++ b/tests/test_atlassian/test_content_converter.py
@@ -1,0 +1,438 @@
+"""Tests for ADF and XHTML → Markdown content converters"""
+
+import pytest
+
+from src.atlassian.content_converter import ADFConverter, XHTMLConverter, convert_content
+
+
+# =====================================================================
+# ADF Converter Tests
+# =====================================================================
+
+class TestADFHeadings:
+    def test_heading_levels(self):
+        for level in range(1, 7):
+            doc = {"type": "doc", "content": [
+                {"type": "heading", "attrs": {"level": level}, "content": [
+                    {"type": "text", "text": f"Heading {level}"}
+                ]}
+            ]}
+            result = ADFConverter().convert(doc)
+            assert result == f"{'#' * level} Heading {level}"
+
+    def test_heading_with_inline_marks(self):
+        doc = {"type": "doc", "content": [
+            {"type": "heading", "attrs": {"level": 2}, "content": [
+                {"type": "text", "text": "bold", "marks": [{"type": "strong"}]},
+                {"type": "text", "text": " heading"},
+            ]}
+        ]}
+        result = ADFConverter().convert(doc)
+        assert result == "## **bold** heading"
+
+
+class TestADFParagraph:
+    def test_simple_paragraph(self):
+        doc = {"type": "doc", "content": [
+            {"type": "paragraph", "content": [
+                {"type": "text", "text": "Hello world"}
+            ]}
+        ]}
+        assert ADFConverter().convert(doc) == "Hello world"
+
+    def test_multiple_paragraphs(self):
+        doc = {"type": "doc", "content": [
+            {"type": "paragraph", "content": [{"type": "text", "text": "First"}]},
+            {"type": "paragraph", "content": [{"type": "text", "text": "Second"}]},
+        ]}
+        result = ADFConverter().convert(doc)
+        assert "First" in result
+        assert "Second" in result
+        assert "\n\n" in result
+
+
+class TestADFCodeBlock:
+    def test_fenced_code_with_language(self):
+        doc = {"type": "doc", "content": [
+            {"type": "codeBlock", "attrs": {"language": "python"}, "content": [
+                {"type": "text", "text": "print('hello')"}
+            ]}
+        ]}
+        result = ADFConverter().convert(doc)
+        assert result == "```python\nprint('hello')\n```"
+
+    def test_fenced_code_no_language(self):
+        doc = {"type": "doc", "content": [
+            {"type": "codeBlock", "attrs": {}, "content": [
+                {"type": "text", "text": "some code"}
+            ]}
+        ]}
+        result = ADFConverter().convert(doc)
+        assert result == "```\nsome code\n```"
+
+
+class TestADFTable:
+    def test_simple_table(self):
+        doc = {"type": "doc", "content": [
+            {"type": "table", "content": [
+                {"type": "tableRow", "content": [
+                    {"type": "tableHeader", "content": [
+                        {"type": "paragraph", "content": [{"type": "text", "text": "Name"}]}
+                    ]},
+                    {"type": "tableHeader", "content": [
+                        {"type": "paragraph", "content": [{"type": "text", "text": "Value"}]}
+                    ]},
+                ]},
+                {"type": "tableRow", "content": [
+                    {"type": "tableCell", "content": [
+                        {"type": "paragraph", "content": [{"type": "text", "text": "foo"}]}
+                    ]},
+                    {"type": "tableCell", "content": [
+                        {"type": "paragraph", "content": [{"type": "text", "text": "bar"}]}
+                    ]},
+                ]},
+            ]}
+        ]}
+        result = ADFConverter().convert(doc)
+        assert "| Name | Value |" in result
+        assert "| --- | --- |" in result
+        assert "| foo | bar |" in result
+
+
+class TestADFLists:
+    def test_bullet_list(self):
+        doc = {"type": "doc", "content": [
+            {"type": "bulletList", "content": [
+                {"type": "listItem", "content": [
+                    {"type": "paragraph", "content": [{"type": "text", "text": "Item A"}]}
+                ]},
+                {"type": "listItem", "content": [
+                    {"type": "paragraph", "content": [{"type": "text", "text": "Item B"}]}
+                ]},
+            ]}
+        ]}
+        result = ADFConverter().convert(doc)
+        assert "- Item A" in result
+        assert "- Item B" in result
+
+    def test_ordered_list(self):
+        doc = {"type": "doc", "content": [
+            {"type": "orderedList", "content": [
+                {"type": "listItem", "content": [
+                    {"type": "paragraph", "content": [{"type": "text", "text": "First"}]}
+                ]},
+                {"type": "listItem", "content": [
+                    {"type": "paragraph", "content": [{"type": "text", "text": "Second"}]}
+                ]},
+            ]}
+        ]}
+        result = ADFConverter().convert(doc)
+        assert "1. First" in result
+        assert "2. Second" in result
+
+
+class TestADFBlockElements:
+    def test_blockquote(self):
+        doc = {"type": "doc", "content": [
+            {"type": "blockquote", "content": [
+                {"type": "paragraph", "content": [{"type": "text", "text": "Quoted text"}]}
+            ]}
+        ]}
+        result = ADFConverter().convert(doc)
+        assert "> Quoted text" in result
+
+    def test_rule(self):
+        doc = {"type": "doc", "content": [{"type": "rule"}]}
+        assert ADFConverter().convert(doc) == "---"
+
+    def test_panel(self):
+        doc = {"type": "doc", "content": [
+            {"type": "panel", "attrs": {"panelType": "info"}, "content": [
+                {"type": "paragraph", "content": [{"type": "text", "text": "Notice"}]}
+            ]}
+        ]}
+        result = ADFConverter().convert(doc)
+        assert "> **Info:** Notice" in result
+
+    def test_expand(self):
+        doc = {"type": "doc", "content": [
+            {"type": "expand", "attrs": {"title": "Click me"}, "content": [
+                {"type": "paragraph", "content": [{"type": "text", "text": "Hidden content"}]}
+            ]}
+        ]}
+        result = ADFConverter().convert(doc)
+        assert "**Click me:** Hidden content" in result
+
+
+class TestADFInlineMarks:
+    def test_strong(self):
+        doc = {"type": "doc", "content": [
+            {"type": "paragraph", "content": [
+                {"type": "text", "text": "bold", "marks": [{"type": "strong"}]}
+            ]}
+        ]}
+        assert "**bold**" in ADFConverter().convert(doc)
+
+    def test_em(self):
+        doc = {"type": "doc", "content": [
+            {"type": "paragraph", "content": [
+                {"type": "text", "text": "italic", "marks": [{"type": "em"}]}
+            ]}
+        ]}
+        assert "*italic*" in ADFConverter().convert(doc)
+
+    def test_code_mark(self):
+        doc = {"type": "doc", "content": [
+            {"type": "paragraph", "content": [
+                {"type": "text", "text": "code", "marks": [{"type": "code"}]}
+            ]}
+        ]}
+        assert "`code`" in ADFConverter().convert(doc)
+
+    def test_link(self):
+        doc = {"type": "doc", "content": [
+            {"type": "paragraph", "content": [
+                {"type": "text", "text": "click", "marks": [
+                    {"type": "link", "attrs": {"href": "https://example.com"}}
+                ]}
+            ]}
+        ]}
+        result = ADFConverter().convert(doc)
+        assert "[click](https://example.com)" in result
+
+    def test_inline_card(self):
+        doc = {"type": "doc", "content": [
+            {"type": "paragraph", "content": [
+                {"type": "inlineCard", "attrs": {"url": "https://example.com/page"}}
+            ]}
+        ]}
+        result = ADFConverter().convert(doc)
+        assert "[https://example.com/page](https://example.com/page)" in result
+
+    def test_mention(self):
+        doc = {"type": "doc", "content": [
+            {"type": "paragraph", "content": [
+                {"type": "mention", "attrs": {"text": "John Doe"}}
+            ]}
+        ]}
+        assert "@John Doe" in ADFConverter().convert(doc)
+
+    def test_strikethrough(self):
+        doc = {"type": "doc", "content": [
+            {"type": "paragraph", "content": [
+                {"type": "text", "text": "deleted", "marks": [{"type": "strike"}]}
+            ]}
+        ]}
+        assert "~~deleted~~" in ADFConverter().convert(doc)
+
+
+class TestADFEdgeCases:
+    def test_empty_doc(self):
+        assert ADFConverter().convert({}) == ""
+        assert ADFConverter().convert(None) == ""
+
+    def test_doc_with_no_content(self):
+        assert ADFConverter().convert({"type": "doc"}) == ""
+
+    def test_unknown_node_type(self):
+        doc = {"type": "doc", "content": [
+            {"type": "unknownNode", "content": [
+                {"type": "paragraph", "content": [{"type": "text", "text": "fallback"}]}
+            ]}
+        ]}
+        result = ADFConverter().convert(doc)
+        assert "fallback" in result
+
+
+# =====================================================================
+# XHTML Converter Tests
+# =====================================================================
+
+class TestXHTMLHeadings:
+    def test_heading_levels(self):
+        for level in range(1, 7):
+            xhtml = f"<h{level}>Heading {level}</h{level}>"
+            result = XHTMLConverter().convert(xhtml)
+            assert f"{'#' * level} Heading {level}" in result
+
+
+class TestXHTMLParagraph:
+    def test_simple_paragraph(self):
+        result = XHTMLConverter().convert("<p>Hello world</p>")
+        assert "Hello world" in result
+
+    def test_paragraph_with_inline(self):
+        result = XHTMLConverter().convert("<p><strong>bold</strong> and <em>italic</em></p>")
+        assert "**bold**" in result
+        assert "*italic*" in result
+
+
+class TestXHTMLCodeBlock:
+    def test_code_macro_with_language(self):
+        xhtml = (
+            '<ac:structured-macro ac:name="code">'
+            '<ac:parameter ac:name="language">python</ac:parameter>'
+            '<ac:plain-text-body>print("hello")</ac:plain-text-body>'
+            '</ac:structured-macro>'
+        )
+        result = XHTMLConverter().convert(xhtml)
+        assert "```python" in result
+        assert 'print("hello")' in result
+        assert "```" in result
+
+    def test_pre_tag(self):
+        result = XHTMLConverter().convert("<pre>some code</pre>")
+        assert "```" in result
+        assert "some code" in result
+
+
+class TestXHTMLTable:
+    def test_simple_table(self):
+        xhtml = (
+            "<table>"
+            "<tr><th>Name</th><th>Value</th></tr>"
+            "<tr><td>foo</td><td>bar</td></tr>"
+            "</table>"
+        )
+        result = XHTMLConverter().convert(xhtml)
+        assert "| Name | Value |" in result
+        assert "| --- | --- |" in result
+        assert "| foo | bar |" in result
+
+    def test_table_with_thead_tbody(self):
+        xhtml = (
+            "<table>"
+            "<thead><tr><th>A</th><th>B</th></tr></thead>"
+            "<tbody><tr><td>1</td><td>2</td></tr></tbody>"
+            "</table>"
+        )
+        result = XHTMLConverter().convert(xhtml)
+        assert "| A | B |" in result
+        assert "| 1 | 2 |" in result
+
+
+class TestXHTMLLists:
+    def test_unordered_list(self):
+        result = XHTMLConverter().convert("<ul><li>A</li><li>B</li></ul>")
+        assert "- A" in result
+        assert "- B" in result
+
+    def test_ordered_list(self):
+        result = XHTMLConverter().convert("<ol><li>First</li><li>Second</li></ol>")
+        assert "1. First" in result
+        assert "2. Second" in result
+
+
+class TestXHTMLLinks:
+    def test_anchor_tag(self):
+        result = XHTMLConverter().convert('<a href="https://example.com">click</a>')
+        assert "[click](https://example.com)" in result
+
+
+class TestXHTMLMacros:
+    def test_info_panel(self):
+        xhtml = (
+            '<ac:structured-macro ac:name="info">'
+            '<ac:rich-text-body><p>Important note</p></ac:rich-text-body>'
+            '</ac:structured-macro>'
+        )
+        result = XHTMLConverter().convert(xhtml)
+        assert "> **Info:**" in result
+        assert "Important note" in result
+
+    def test_warning_panel(self):
+        xhtml = (
+            '<ac:structured-macro ac:name="warning">'
+            '<ac:rich-text-body><p>Be careful</p></ac:rich-text-body>'
+            '</ac:structured-macro>'
+        )
+        result = XHTMLConverter().convert(xhtml)
+        assert "> **Warning:**" in result
+
+    def test_expand_macro(self):
+        xhtml = (
+            '<ac:structured-macro ac:name="expand">'
+            '<ac:parameter ac:name="title">Details</ac:parameter>'
+            '<ac:rich-text-body><p>Expanded content</p></ac:rich-text-body>'
+            '</ac:structured-macro>'
+        )
+        result = XHTMLConverter().convert(xhtml)
+        assert "**Details:**" in result
+        assert "Expanded content" in result
+
+    def test_noformat_macro(self):
+        xhtml = (
+            '<ac:structured-macro ac:name="noformat">'
+            '<ac:plain-text-body>raw text here</ac:plain-text-body>'
+            '</ac:structured-macro>'
+        )
+        result = XHTMLConverter().convert(xhtml)
+        assert "```" in result
+        assert "raw text here" in result
+
+
+class TestXHTMLImage:
+    def test_img_tag(self):
+        result = XHTMLConverter().convert('<img src="photo.png" alt="Photo" />')
+        assert "![Photo](photo.png)" in result
+
+    def test_ac_image(self):
+        xhtml = (
+            '<ac:image>'
+            '<ri:attachment ri:filename="diagram.png" />'
+            '</ac:image>'
+        )
+        result = XHTMLConverter().convert(xhtml)
+        assert "![](diagram.png)" in result
+
+
+class TestXHTMLBlockElements:
+    def test_blockquote(self):
+        result = XHTMLConverter().convert("<blockquote>Quoted text</blockquote>")
+        assert "> Quoted text" in result
+
+    def test_horizontal_rule(self):
+        result = XHTMLConverter().convert("<hr />")
+        assert "---" in result
+
+    def test_inline_code(self):
+        result = XHTMLConverter().convert("<code>foo()</code>")
+        assert "`foo()`" in result
+
+
+class TestXHTMLEdgeCases:
+    def test_empty_input(self):
+        assert XHTMLConverter().convert("") == ""
+        assert XHTMLConverter().convert("   ") == ""
+
+    def test_plain_text(self):
+        result = XHTMLConverter().convert("Just plain text")
+        assert "Just plain text" in result
+
+
+# =====================================================================
+# convert_content() dispatch tests
+# =====================================================================
+
+class TestConvertContent:
+    def test_adf_dispatch(self):
+        doc = {"type": "doc", "content": [
+            {"type": "paragraph", "content": [{"type": "text", "text": "ADF text"}]}
+        ]}
+        assert "ADF text" in convert_content(doc, "adf")
+
+    def test_storage_dispatch(self):
+        assert "Storage text" in convert_content("<p>Storage text</p>", "storage")
+
+    def test_xhtml_dispatch(self):
+        assert "XHTML text" in convert_content("<p>XHTML text</p>", "xhtml")
+
+    def test_adf_with_non_dict(self):
+        assert convert_content("not a dict", "adf") == ""
+
+    def test_storage_with_non_string(self):
+        assert convert_content({"not": "string"}, "storage") == ""
+
+    def test_unknown_format(self):
+        result = convert_content("some body", "unknown_fmt")
+        assert "some body" in result

--- a/tests/test_atlassian/test_factory.py
+++ b/tests/test_atlassian/test_factory.py
@@ -1,0 +1,74 @@
+"""Tests for AtlassianAuthFactory"""
+
+import pytest
+
+from src.atlassian.base import AuthMethod, AtlassianConfigError
+from src.atlassian.auth.basic_auth import BasicAuthProvider
+from src.atlassian.auth.pat_auth import PATAuthProvider
+from src.atlassian.auth.oauth2_auth import OAuth2AuthProvider
+from src.atlassian.config import ConfluenceConfig
+from src.atlassian.factory import AtlassianAuthFactory
+
+
+class TestRegistration:
+    def test_built_in_providers_registered(self):
+        registered = AtlassianAuthFactory.list_registered()
+        assert "basic" in registered
+        assert "pat" in registered
+        assert "oauth2" in registered
+
+    def test_create_basic_provider(self):
+        from src.atlassian.base import DeploymentType
+        config = ConfluenceConfig(
+            base_url="https://x.atlassian.net",
+            deployment_type=DeploymentType.CLOUD,
+            auth_method=AuthMethod.BASIC,
+            auth_config={
+                "username": "user@example.com",
+                "api_token": "tok",
+                "base_url": "https://x.atlassian.net",
+            },
+        )
+        provider = AtlassianAuthFactory.create_auth_provider(config)
+        assert isinstance(provider, BasicAuthProvider)
+
+    def test_create_pat_provider(self):
+        from src.atlassian.base import DeploymentType
+        config = ConfluenceConfig(
+            base_url="https://confluence.corp.local",
+            deployment_type=DeploymentType.ON_PREM,
+            auth_method=AuthMethod.PAT,
+            auth_config={
+                "pat": "my-pat",
+                "base_url": "https://confluence.corp.local",
+            },
+        )
+        provider = AtlassianAuthFactory.create_auth_provider(config)
+        assert isinstance(provider, PATAuthProvider)
+
+    def test_create_http_client(self):
+        from src.atlassian.base import DeploymentType
+        from src.atlassian.http_client import AtlassianHTTPClient
+        config = ConfluenceConfig(
+            base_url="https://confluence.corp.local",
+            deployment_type=DeploymentType.ON_PREM,
+            auth_method=AuthMethod.PAT,
+            auth_config={
+                "pat": "my-pat",
+                "base_url": "https://confluence.corp.local",
+            },
+        )
+        client = AtlassianAuthFactory.create_http_client(config)
+        assert isinstance(client, AtlassianHTTPClient)
+
+
+class TestClearRegistry:
+    def test_clear_and_re_register(self):
+        AtlassianAuthFactory.clear_registry()
+        assert AtlassianAuthFactory.list_registered() == []
+
+        # Re-register so other tests aren't affected
+        AtlassianAuthFactory.register_auth_provider(AuthMethod.BASIC, BasicAuthProvider)
+        AtlassianAuthFactory.register_auth_provider(AuthMethod.PAT, PATAuthProvider)
+        AtlassianAuthFactory.register_auth_provider(AuthMethod.OAUTH2, OAuth2AuthProvider)
+        assert len(AtlassianAuthFactory.list_registered()) == 3

--- a/tests/test_atlassian/test_http_client.py
+++ b/tests/test_atlassian/test_http_client.py
@@ -1,0 +1,192 @@
+"""Tests for AtlassianHTTPClient — retry, rate-limit, auth injection"""
+
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
+
+from src.atlassian.base import (
+    AuthHeaders,
+    AuthMethod,
+    AtlassianAPIError,
+    AtlassianAuthError,
+    AtlassianRateLimitError,
+)
+from src.atlassian.http_client import AtlassianHTTPClient
+
+
+def _mock_auth_provider():
+    provider = AsyncMock()
+    provider.get_auth_headers = AsyncMock(return_value=AuthHeaders(
+        headers={"Authorization": "Bearer test-token", "Content-Type": "application/json", "Accept": "application/json"},
+        auth_method=AuthMethod.PAT,
+    ))
+    provider.initialize = AsyncMock()
+    provider.close = AsyncMock()
+    provider.refresh_if_needed = AsyncMock()
+    return provider
+
+
+def _make_response(status, body=None, content_type="application/json", headers=None):
+    resp = AsyncMock()
+    resp.status = status
+    resp.content_type = content_type
+    resp.headers = headers or {}
+    if isinstance(body, dict):
+        resp.json = AsyncMock(return_value=body)
+    else:
+        resp.text = AsyncMock(return_value=body or "")
+        resp.json = AsyncMock(return_value={})
+    resp.__aenter__ = AsyncMock(return_value=resp)
+    resp.__aexit__ = AsyncMock(return_value=False)
+    return resp
+
+
+class TestSuccessfulRequests:
+    @pytest.mark.asyncio
+    async def test_get_json(self):
+        auth = _mock_auth_provider()
+        client = AtlassianHTTPClient(auth, "https://example.com", max_retries=0)
+        resp = _make_response(200, {"ok": True})
+
+        mock_session = MagicMock()
+        mock_session.request = MagicMock(return_value=resp)
+        client._session = mock_session
+
+        result = await client.request("GET", "/api/test")
+        assert result == {"ok": True}
+
+    @pytest.mark.asyncio
+    async def test_non_json_response(self):
+        auth = _mock_auth_provider()
+        client = AtlassianHTTPClient(auth, "https://example.com", max_retries=0)
+        resp = _make_response(200, "plain text", content_type="text/plain")
+
+        mock_session = MagicMock()
+        mock_session.request = MagicMock(return_value=resp)
+        client._session = mock_session
+
+        result = await client.request("GET", "/api/text")
+        assert result["_raw"] == "plain text"
+
+
+class TestRetryLogic:
+    @pytest.mark.asyncio
+    async def test_retries_on_500(self):
+        auth = _mock_auth_provider()
+        client = AtlassianHTTPClient(auth, "https://example.com", max_retries=2)
+
+        fail_resp = _make_response(500, "server error")
+        ok_resp = _make_response(200, {"ok": True})
+
+        call_count = 0
+        def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return fail_resp if call_count <= 1 else ok_resp
+
+        mock_session = MagicMock()
+        mock_session.request = MagicMock(side_effect=side_effect)
+        client._session = mock_session
+
+        with patch("src.atlassian.http_client.asyncio.sleep", new_callable=AsyncMock):
+            result = await client.request("GET", "/api/test")
+        assert result == {"ok": True}
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_raises_after_max_retries(self):
+        auth = _mock_auth_provider()
+        client = AtlassianHTTPClient(auth, "https://example.com", max_retries=1)
+
+        fail_resp = _make_response(502, "bad gateway")
+        mock_session = MagicMock()
+        mock_session.request = MagicMock(return_value=fail_resp)
+        client._session = mock_session
+
+        with patch("src.atlassian.http_client.asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(AtlassianAPIError, match="502"):
+                await client.request("GET", "/api/fail")
+
+
+class TestAuthRefresh:
+    @pytest.mark.asyncio
+    async def test_401_triggers_refresh_and_retry(self):
+        auth = _mock_auth_provider()
+        client = AtlassianHTTPClient(auth, "https://example.com", max_retries=2)
+
+        unauth_resp = _make_response(401, "unauthorized")
+        ok_resp = _make_response(200, {"ok": True})
+
+        call_count = 0
+        def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return unauth_resp if call_count <= 1 else ok_resp
+
+        mock_session = MagicMock()
+        mock_session.request = MagicMock(side_effect=side_effect)
+        client._session = mock_session
+
+        result = await client.request("GET", "/api/test")
+        assert result == {"ok": True}
+        auth.refresh_if_needed.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_double_401_raises(self):
+        auth = _mock_auth_provider()
+        client = AtlassianHTTPClient(auth, "https://example.com", max_retries=2)
+
+        unauth_resp = _make_response(401, "unauthorized")
+        mock_session = MagicMock()
+        mock_session.request = MagicMock(return_value=unauth_resp)
+        client._session = mock_session
+
+        with pytest.raises(AtlassianAuthError, match="Authentication failed"):
+            await client.request("GET", "/api/test")
+
+
+class TestRateLimit:
+    @pytest.mark.asyncio
+    async def test_429_respects_retry_after(self):
+        auth = _mock_auth_provider()
+        client = AtlassianHTTPClient(auth, "https://example.com", max_retries=2)
+
+        rate_resp = _make_response(429, "rate limited", headers={"Retry-After": "1"})
+        ok_resp = _make_response(200, {"ok": True})
+
+        call_count = 0
+        def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return rate_resp if call_count <= 1 else ok_resp
+
+        mock_session = MagicMock()
+        mock_session.request = MagicMock(side_effect=side_effect)
+        client._session = mock_session
+
+        with patch("src.atlassian.http_client.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await client.request("GET", "/api/test")
+        assert result == {"ok": True}
+        mock_sleep.assert_called_once_with(1.0)
+
+    @pytest.mark.asyncio
+    async def test_429_raises_after_retries(self):
+        auth = _mock_auth_provider()
+        client = AtlassianHTTPClient(auth, "https://example.com", max_retries=0)
+
+        rate_resp = _make_response(429, "rate limited")
+        mock_session = MagicMock()
+        mock_session.request = MagicMock(return_value=rate_resp)
+        client._session = mock_session
+
+        with pytest.raises(AtlassianRateLimitError):
+            await client.request("GET", "/api/test")
+
+
+class TestNotInitialized:
+    @pytest.mark.asyncio
+    async def test_raises_if_not_initialized(self):
+        auth = _mock_auth_provider()
+        client = AtlassianHTTPClient(auth, "https://example.com")
+        with pytest.raises(RuntimeError, match="not initialized"):
+            await client.request("GET", "/")

--- a/tests/test_atlassian/test_oauth2_auth.py
+++ b/tests/test_atlassian/test_oauth2_auth.py
@@ -1,0 +1,126 @@
+"""Tests for OAuth2AuthProvider"""
+
+import time
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from src.atlassian.auth.oauth2_auth import OAuth2AuthProvider, EXPIRY_BUFFER_SECONDS
+from src.atlassian.base import AuthMethod, AtlassianConfigError, AtlassianAuthError
+
+
+def _config(overrides=None):
+    cfg = {
+        "oauth2_client_id": "cid",
+        "oauth2_client_secret": "csecret",
+        "base_url": "https://myorg.atlassian.net",
+        "oauth2_access_token": "access-tok",
+        "oauth2_refresh_token": "refresh-tok",
+        "oauth2_token_expires_at": str(time.time() + 7200),
+    }
+    if overrides:
+        cfg.update(overrides)
+    return cfg
+
+
+class TestValidation:
+    def test_valid(self):
+        p = OAuth2AuthProvider(_config())
+        assert p.client_id == "cid"
+
+    def test_missing_client_id(self):
+        with pytest.raises(AtlassianConfigError, match="oauth2_client_id"):
+            OAuth2AuthProvider(_config({"oauth2_client_id": ""}))
+
+    def test_missing_tokens(self):
+        with pytest.raises(AtlassianConfigError, match="oauth2_access_token or oauth2_refresh_token"):
+            OAuth2AuthProvider(_config({
+                "oauth2_access_token": None,
+                "oauth2_refresh_token": None,
+            }))
+
+    def test_refresh_token_only_is_ok(self):
+        p = OAuth2AuthProvider(_config({"oauth2_access_token": None}))
+        assert p._refresh_token == "refresh-tok"
+
+
+class TestHeaders:
+    @pytest.mark.asyncio
+    async def test_bearer_header(self):
+        p = OAuth2AuthProvider(_config())
+        auth = await p.get_auth_headers()
+        assert auth.headers["Authorization"] == "Bearer access-tok"
+        assert auth.auth_method == AuthMethod.OAUTH2
+        assert auth.expires_at is not None
+
+
+class TestTokenValidity:
+    @pytest.mark.asyncio
+    async def test_valid_token(self):
+        p = OAuth2AuthProvider(_config())
+        assert await p.is_token_valid() is True
+
+    @pytest.mark.asyncio
+    async def test_expired_token(self):
+        p = OAuth2AuthProvider(_config({"oauth2_token_expires_at": str(time.time() - 100)}))
+        assert await p.is_token_valid() is False
+
+    @pytest.mark.asyncio
+    async def test_no_expiry_assumed_valid(self):
+        p = OAuth2AuthProvider(_config())
+        p._expires_at = None
+        assert await p.is_token_valid() is True
+
+
+class TestRefresh:
+    @pytest.mark.asyncio
+    async def test_refresh_when_near_expiry(self):
+        cfg = _config({"oauth2_token_expires_at": str(time.time() + 60)})  # within buffer
+        p = OAuth2AuthProvider(cfg)
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "expires_in": 3600,
+        })
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.post = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("src.atlassian.auth.oauth2_auth.aiohttp.ClientSession", return_value=mock_session):
+            await p.refresh_if_needed()
+            assert p._access_token == "new-access"
+            assert p._refresh_token == "new-refresh"
+
+    @pytest.mark.asyncio
+    async def test_no_refresh_when_far_from_expiry(self):
+        cfg = _config({"oauth2_token_expires_at": str(time.time() + 7200)})
+        p = OAuth2AuthProvider(cfg)
+        original_token = p._access_token
+        await p.refresh_if_needed()
+        assert p._access_token == original_token
+
+    @pytest.mark.asyncio
+    async def test_refresh_failure_raises(self):
+        cfg = _config({"oauth2_token_expires_at": str(time.time() + 60)})
+        p = OAuth2AuthProvider(cfg)
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 400
+        mock_resp.text = AsyncMock(return_value="bad request")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.post = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("src.atlassian.auth.oauth2_auth.aiohttp.ClientSession", return_value=mock_session):
+            with pytest.raises(AtlassianAuthError, match="Token refresh failed"):
+                await p.refresh_if_needed()

--- a/tests/test_atlassian/test_pat_auth.py
+++ b/tests/test_atlassian/test_pat_auth.py
@@ -1,0 +1,65 @@
+"""Tests for PATAuthProvider"""
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from src.atlassian.auth.pat_auth import PATAuthProvider
+from src.atlassian.base import AuthMethod, AtlassianConfigError
+
+
+def _config(overrides=None):
+    cfg = {
+        "pat": "my-personal-access-token",
+        "base_url": "https://confluence.corp.local",
+    }
+    if overrides:
+        cfg.update(overrides)
+    return cfg
+
+
+class TestValidation:
+    def test_valid(self):
+        p = PATAuthProvider(_config())
+        assert p.pat == "my-personal-access-token"
+
+    def test_missing_pat(self):
+        with pytest.raises(AtlassianConfigError, match="pat"):
+            PATAuthProvider(_config({"pat": ""}))
+
+    def test_missing_base_url(self):
+        with pytest.raises(AtlassianConfigError, match="base_url"):
+            PATAuthProvider(_config({"base_url": ""}))
+
+
+class TestHeaders:
+    @pytest.mark.asyncio
+    async def test_bearer_header(self):
+        p = PATAuthProvider(_config())
+        auth = await p.get_auth_headers()
+        assert auth.headers["Authorization"] == "Bearer my-personal-access-token"
+        assert auth.auth_method == AuthMethod.PAT
+
+    @pytest.mark.asyncio
+    async def test_token_always_valid(self):
+        p = PATAuthProvider(_config())
+        assert await p.is_token_valid() is True
+
+
+class TestHealthCheck:
+    @pytest.mark.asyncio
+    async def test_healthy(self):
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("src.atlassian.auth.pat_auth.aiohttp.ClientSession", return_value=mock_session):
+            p = PATAuthProvider(_config())
+            health = await p.health_check()
+            assert health.is_healthy
+            assert health.auth_method == "pat"


### PR DESCRIPTION
## Summary

- **Content converters**: `ADFConverter` (Cloud JSON) and `XHTMLConverter` (On-Prem storage format) convert Confluence page bodies to Markdown using only stdlib `xml.etree.ElementTree` — no new dependencies
- **ConfluenceCrawler**: Fetches pages via REST API with Cloud v2 (cursor pagination) and On-Prem v1 (offset pagination) support. Includes `crawl_page`, `crawl_page_by_url`, `crawl_space`, and `crawl_page_tree` (BFS with cycle detection, max depth/pages limits)
- **Structured dataclasses**: `ConfluencePage`, `CrawlResult`, `CrawlSummary` for downstream RAG processing (Story 3.3)
- **73 unit tests** covering converters, crawler, pagination, URL parsing, error handling (403/404 skip), and edge cases

Builds on Story 3.1 (Atlassian auth provider) which is included in this branch.

## Test plan

- [x] `pytest tests/test_atlassian/test_content_converter.py` — 50 tests pass
- [x] `pytest tests/test_atlassian/test_confluence_crawler.py` — 23 tests pass
- [x] `python -c "from src.atlassian import ConfluenceCrawler, ConfluencePage, CrawlResult"` — imports OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)