### PR TITLE
feat: Story 3.1 — Atlassian Authentication Provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,3 +55,38 @@ KG_NEO4J_DATABASE=neo4j
 # by setting the same connection details for both. They use different node labels:
 # - Vector DB: Document, CodeExample, Source nodes
 # - Knowledge Graph: Repository, File, Class, Function, Method nodes
+
+# ─── Confluence Integration ─────────────────────────────────────────
+# Base URL of your Confluence instance
+CONFLUENCE_URL=https://your-org.atlassian.net
+
+# Deployment type (auto-detected from URL if not set): cloud, on_prem, data_center
+# CONFLUENCE_DEPLOYMENT_TYPE=cloud
+
+# Auth method (auto-detected from available credentials if not set): basic, pat, oauth2
+# CONFLUENCE_AUTH_METHOD=basic
+
+# Basic Auth (Cloud) — email + API token
+CONFLUENCE_USERNAME=your_email@example.com
+CONFLUENCE_API_TOKEN=your_confluence_api_token
+
+# Personal Access Token (On-Prem / Data Center)
+# CONFLUENCE_PAT=your_personal_access_token
+
+# OAuth 2.0 (Cloud Enterprise) — run scripts/confluence_oauth_setup.py to obtain tokens
+# CONFLUENCE_OAUTH2_CLIENT_ID=your_oauth2_client_id
+# CONFLUENCE_OAUTH2_CLIENT_SECRET=your_oauth2_client_secret
+# CONFLUENCE_OAUTH2_ACCESS_TOKEN=your_access_token
+# CONFLUENCE_OAUTH2_REFRESH_TOKEN=your_refresh_token
+# CONFLUENCE_OAUTH2_TOKEN_EXPIRES_AT=unix_timestamp
+# CONFLUENCE_CLOUD_ID=your_cloud_id
+
+# SSL Configuration
+# CONFLUENCE_SSL_VERIFY=true
+# CONFLUENCE_CA_BUNDLE=/path/to/ca-bundle.pem
+
+# Connection tuning
+# CONFLUENCE_TIMEOUT=30.0
+# CONFLUENCE_CONNECT_TIMEOUT=10.0
+# CONFLUENCE_POOL_SIZE=10
+# CONFLUENCE_MAX_RETRIES=3

--- a/scripts/confluence_oauth_setup.py
+++ b/scripts/confluence_oauth_setup.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""One-time CLI tool for Atlassian OAuth 2.0 3LO browser flow.
+
+Usage:
+    python scripts/confluence_oauth_setup.py \
+        --client-id YOUR_CLIENT_ID \
+        --client-secret YOUR_CLIENT_SECRET \
+        [--port 8089]
+
+The script starts a local HTTP server, opens the Atlassian authorization URL
+in the default browser, waits for the redirect callback, exchanges the
+authorization code for tokens, and prints the resulting environment variables.
+"""
+
+import argparse
+import http.server
+import json
+import os
+import sys
+import threading
+import urllib.parse
+import urllib.request
+import webbrowser
+
+AUTHORIZE_URL = "https://auth.atlassian.com/authorize"
+TOKEN_URL = "https://auth.atlassian.com/oauth/token"
+SCOPES = [
+    "read:confluence-content.all",
+    "read:confluence-space.summary",
+    "offline_access",  # needed for refresh_token
+]
+
+
+class CallbackHandler(http.server.BaseHTTPRequestHandler):
+    """Receives the OAuth redirect and extracts the authorization code."""
+
+    authorization_code = None
+
+    def do_GET(self):
+        parsed = urllib.parse.urlparse(self.path)
+        params = urllib.parse.parse_qs(parsed.query)
+        code = params.get("code", [None])[0]
+        if code:
+            CallbackHandler.authorization_code = code
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            self.wfile.write(
+                b"<h2>Authorization successful!</h2>"
+                b"<p>You can close this tab and return to the terminal.</p>"
+            )
+        else:
+            error = params.get("error", ["unknown"])[0]
+            self.send_response(400)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            self.wfile.write(f"<h2>Error: {error}</h2>".encode())
+
+    def log_message(self, format, *args):
+        pass  # suppress logs
+
+
+def exchange_code(client_id: str, client_secret: str, code: str, redirect_uri: str) -> dict:
+    payload = json.dumps({
+        "grant_type": "authorization_code",
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "code": code,
+        "redirect_uri": redirect_uri,
+    }).encode()
+    req = urllib.request.Request(
+        TOKEN_URL,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read())
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Atlassian OAuth 2.0 setup")
+    parser.add_argument("--client-id", required=True, help="OAuth2 client ID")
+    parser.add_argument("--client-secret", required=True, help="OAuth2 client secret")
+    parser.add_argument("--port", type=int, default=8089, help="Local callback port")
+    args = parser.parse_args()
+
+    redirect_uri = f"http://localhost:{args.port}/callback"
+
+    # Build authorize URL
+    params = urllib.parse.urlencode({
+        "audience": "api.atlassian.com",
+        "client_id": args.client_id,
+        "scope": " ".join(SCOPES),
+        "redirect_uri": redirect_uri,
+        "response_type": "code",
+        "prompt": "consent",
+    })
+    auth_url = f"{AUTHORIZE_URL}?{params}"
+
+    # Start local server
+    server = http.server.HTTPServer(("localhost", args.port), CallbackHandler)
+    thread = threading.Thread(target=server.handle_request, daemon=True)
+    thread.start()
+
+    print(f"Opening browser for authorization...\n{auth_url}\n")
+    webbrowser.open(auth_url)
+    print("Waiting for callback...")
+    thread.join(timeout=120)
+    server.server_close()
+
+    code = CallbackHandler.authorization_code
+    if not code:
+        print("ERROR: No authorization code received.", file=sys.stderr)
+        sys.exit(1)
+
+    print("Exchanging authorization code for tokens...")
+    tokens = exchange_code(args.client_id, args.client_secret, code, redirect_uri)
+
+    print("\n# Add these to your .env file:")
+    print(f"CONFLUENCE_OAUTH2_CLIENT_ID={args.client_id}")
+    print(f"CONFLUENCE_OAUTH2_CLIENT_SECRET={args.client_secret}")
+    print(f"CONFLUENCE_OAUTH2_ACCESS_TOKEN={tokens['access_token']}")
+    if "refresh_token" in tokens:
+        print(f"CONFLUENCE_OAUTH2_REFRESH_TOKEN={tokens['refresh_token']}")
+    if "expires_in" in tokens:
+        import time
+        expires_at = int(time.time() + tokens["expires_in"])
+        print(f"CONFLUENCE_OAUTH2_TOKEN_EXPIRES_AT={expires_at}")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_confluence_config.py
+++ b/scripts/validate_confluence_config.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Validate Confluence configuration from environment variables.
+
+Usage:
+    python scripts/validate_confluence_config.py
+"""
+
+import asyncio
+import sys
+import os
+
+# Ensure the project root is on sys.path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.atlassian import ConfluenceConfig, AtlassianAuthFactory, AtlassianConfigError
+
+
+async def main():
+    print("Validating Confluence configuration...\n")
+
+    # 1. Load config
+    try:
+        config = ConfluenceConfig.from_env()
+    except AtlassianConfigError as e:
+        print(f"FAIL  Configuration error: {e}")
+        sys.exit(1)
+
+    print(f"  URL:             {config.base_url}")
+    print(f"  Deployment type: {config.deployment_type.value}")
+    print(f"  Auth method:     {config.auth_method.value}")
+    print(f"  SSL verify:      {config.ssl_verify}")
+    print(f"  Pool size:       {config.pool_size}")
+    print(f"  Max retries:     {config.max_retries}")
+    print()
+
+    # 2. Create auth provider
+    try:
+        auth = AtlassianAuthFactory.create_auth_provider(config)
+    except Exception as e:
+        print(f"FAIL  Could not create auth provider: {e}")
+        sys.exit(1)
+
+    print(f"  Auth provider:   {type(auth).__name__}")
+
+    # 3. Health check (requires network)
+    try:
+        await auth.initialize()
+        health = await auth.health_check()
+        await auth.close()
+        if health.is_healthy:
+            print(f"  Health check:    PASS ({health.response_time_ms:.0f}ms)")
+        else:
+            print(f"  Health check:    FAIL - {health.error_message}")
+    except Exception as e:
+        print(f"  Health check:    SKIP (could not connect: {e})")
+
+    print("\nConfiguration is valid.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/atlassian/__init__.py
+++ b/src/atlassian/__init__.py
@@ -1,0 +1,47 @@
+"""Atlassian authentication and HTTP client package"""
+
+from .base import (
+    AuthHeaders,
+    AuthHealthStatus,
+    AuthMethod,
+    AtlassianAPIError,
+    AtlassianAuthError,
+    AtlassianConfigError,
+    AtlassianError,
+    AtlassianRateLimitError,
+    DeploymentType,
+)
+from .auth import (
+    AtlassianAuthProvider,
+    BasicAuthProvider,
+    OAuth2AuthProvider,
+    PATAuthProvider,
+)
+from .config import ConfluenceConfig
+from .factory import AtlassianAuthFactory
+from .http_client import AtlassianHTTPClient
+
+__all__ = [
+    # Enums
+    "DeploymentType",
+    "AuthMethod",
+    # Dataclasses
+    "AuthHeaders",
+    "AuthHealthStatus",
+    # Exceptions
+    "AtlassianError",
+    "AtlassianAuthError",
+    "AtlassianConfigError",
+    "AtlassianAPIError",
+    "AtlassianRateLimitError",
+    # Auth providers
+    "AtlassianAuthProvider",
+    "BasicAuthProvider",
+    "PATAuthProvider",
+    "OAuth2AuthProvider",
+    # Config
+    "ConfluenceConfig",
+    # Factory & client
+    "AtlassianAuthFactory",
+    "AtlassianHTTPClient",
+]

--- a/src/atlassian/auth/__init__.py
+++ b/src/atlassian/auth/__init__.py
@@ -1,0 +1,13 @@
+"""Atlassian authentication providers"""
+
+from .base_auth import AtlassianAuthProvider
+from .basic_auth import BasicAuthProvider
+from .pat_auth import PATAuthProvider
+from .oauth2_auth import OAuth2AuthProvider
+
+__all__ = [
+    "AtlassianAuthProvider",
+    "BasicAuthProvider",
+    "PATAuthProvider",
+    "OAuth2AuthProvider",
+]

--- a/src/atlassian/auth/base_auth.py
+++ b/src/atlassian/auth/base_auth.py
@@ -1,0 +1,65 @@
+"""Abstract base class for Atlassian authentication providers"""
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Dict, Any
+
+from ..base import AuthHeaders, AuthHealthStatus
+
+logger = logging.getLogger(__name__)
+
+
+class AtlassianAuthProvider(ABC):
+    """Abstract base class for Atlassian authentication providers.
+
+    Follows the pattern from ``src/ai_providers/base.py`` (EmbeddingProvider):
+    ``__init__`` accepts a config dict and calls ``_validate_config()`` immediately.
+    """
+
+    def __init__(self, config: Dict[str, Any]):
+        self.config = config
+        self._validate_config()
+
+    @abstractmethod
+    def _validate_config(self) -> None:
+        """Validate provider-specific configuration.
+
+        Raises:
+            AtlassianConfigError: If configuration is invalid.
+        """
+
+    async def initialize(self) -> None:
+        """Initialize any async resources (default no-op)."""
+
+    async def close(self) -> None:
+        """Release any async resources (default no-op)."""
+
+    @abstractmethod
+    async def get_auth_headers(self) -> AuthHeaders:
+        """Return current authentication headers.
+
+        Returns:
+            AuthHeaders with the appropriate Authorization header.
+        """
+
+    @abstractmethod
+    async def health_check(self) -> AuthHealthStatus:
+        """Verify credentials are valid by making a lightweight API call.
+
+        Returns:
+            AuthHealthStatus with result details.
+        """
+
+    @abstractmethod
+    async def is_token_valid(self) -> bool:
+        """Check whether the current token/credentials are still valid.
+
+        Returns:
+            True if valid, False otherwise.
+        """
+
+    async def refresh_if_needed(self) -> None:
+        """Refresh credentials if they are about to expire.
+
+        Default is a no-op. OAuth2 overrides this.
+        """

--- a/src/atlassian/auth/basic_auth.py
+++ b/src/atlassian/auth/basic_auth.py
@@ -1,0 +1,86 @@
+"""Basic authentication provider for Atlassian Cloud (email + API token)"""
+
+import base64
+import logging
+import time
+from typing import Dict, Any
+
+import aiohttp
+
+from ..base import AuthHeaders, AuthHealthStatus, AuthMethod, AtlassianConfigError
+from .base_auth import AtlassianAuthProvider
+
+logger = logging.getLogger(__name__)
+
+
+class BasicAuthProvider(AtlassianAuthProvider):
+    """Basic Auth for Atlassian Cloud: ``Authorization: Basic base64(email:api_token)``"""
+
+    def __init__(self, config: Dict[str, Any]):
+        super().__init__(config)
+        self.username = config["username"]
+        self.api_token = config["api_token"]
+        self.base_url = config["base_url"]
+
+    def _validate_config(self) -> None:
+        missing = []
+        if not self.config.get("username"):
+            missing.append("username")
+        if not self.config.get("api_token"):
+            missing.append("api_token")
+        if not self.config.get("base_url"):
+            missing.append("base_url")
+        if missing:
+            raise AtlassianConfigError(
+                f"BasicAuthProvider missing required config: {missing}"
+            )
+
+    async def get_auth_headers(self) -> AuthHeaders:
+        credentials = base64.b64encode(
+            f"{self.username}:{self.api_token}".encode()
+        ).decode()
+        return AuthHeaders(
+            headers={
+                "Authorization": f"Basic {credentials}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+            auth_method=AuthMethod.BASIC,
+        )
+
+    async def is_token_valid(self) -> bool:
+        # API tokens do not expire
+        return True
+
+    async def health_check(self) -> AuthHealthStatus:
+        start = time.time()
+        try:
+            auth = await self.get_auth_headers()
+            async with aiohttp.ClientSession() as session:
+                url = f"{self.base_url}/wiki/rest/api/space?limit=1"
+                async with session.get(url, headers=auth.headers) as resp:
+                    elapsed = (time.time() - start) * 1000
+                    if resp.status == 200:
+                        return AuthHealthStatus(
+                            is_healthy=True,
+                            auth_method=AuthMethod.BASIC.value,
+                            deployment_type="cloud",
+                            response_time_ms=elapsed,
+                        )
+                    body = await resp.text()
+                    return AuthHealthStatus(
+                        is_healthy=False,
+                        auth_method=AuthMethod.BASIC.value,
+                        deployment_type="cloud",
+                        response_time_ms=elapsed,
+                        error_message=f"HTTP {resp.status}: {body[:200]}",
+                    )
+        except Exception as e:
+            elapsed = (time.time() - start) * 1000
+            return AuthHealthStatus(
+                is_healthy=False,
+                auth_method=AuthMethod.BASIC.value,
+                deployment_type="cloud",
+                response_time_ms=elapsed,
+                error_message=str(e),
+            )

--- a/src/atlassian/auth/oauth2_auth.py
+++ b/src/atlassian/auth/oauth2_auth.py
@@ -1,0 +1,170 @@
+"""OAuth 2.0 (3-legged) authentication for Atlassian Cloud Enterprise"""
+
+import asyncio
+import logging
+import time
+from typing import Dict, Any, Optional
+
+import aiohttp
+
+from ..base import (
+    AuthHeaders,
+    AuthHealthStatus,
+    AuthMethod,
+    AtlassianAuthError,
+    AtlassianConfigError,
+)
+from .base_auth import AtlassianAuthProvider
+
+logger = logging.getLogger(__name__)
+
+TOKEN_URL = "https://auth.atlassian.com/oauth/token"
+EXPIRY_BUFFER_SECONDS = 300  # refresh 5 min before expiry
+
+
+class OAuth2AuthProvider(AtlassianAuthProvider):
+    """OAuth 2.0 3LO for Atlassian Cloud.
+
+    Tokens are expected to be pre-cached via env vars (headless operation) or
+    obtained through the ``scripts/confluence_oauth_setup.py`` browser flow.
+    Automatic refresh is performed via ``refresh_token`` grant.
+    """
+
+    REQUIRED_SCOPES = [
+        "read:confluence-content.all",
+        "read:confluence-space.summary",
+    ]
+
+    def __init__(self, config: Dict[str, Any]):
+        super().__init__(config)
+        self.client_id: str = config["oauth2_client_id"]
+        self.client_secret: str = config["oauth2_client_secret"]
+        self.base_url: str = config["base_url"]
+        self.cloud_id: Optional[str] = config.get("cloud_id")
+
+        # Tokens
+        self._access_token: Optional[str] = config.get("oauth2_access_token")
+        self._refresh_token: Optional[str] = config.get("oauth2_refresh_token")
+        self._expires_at: Optional[float] = None
+
+        if self._access_token and config.get("oauth2_token_expires_at"):
+            self._expires_at = float(config["oauth2_token_expires_at"])
+
+        # Concurrency guard for refresh
+        self._refresh_lock = asyncio.Lock()
+
+    def _validate_config(self) -> None:
+        missing = []
+        for key in ("oauth2_client_id", "oauth2_client_secret", "base_url"):
+            if not self.config.get(key):
+                missing.append(key)
+        if missing:
+            raise AtlassianConfigError(
+                f"OAuth2AuthProvider missing required config: {missing}"
+            )
+        # Must have either access_token or refresh_token to function
+        if not self.config.get("oauth2_access_token") and not self.config.get("oauth2_refresh_token"):
+            raise AtlassianConfigError(
+                "OAuth2AuthProvider requires at least one of "
+                "oauth2_access_token or oauth2_refresh_token"
+            )
+
+    async def get_auth_headers(self) -> AuthHeaders:
+        await self.refresh_if_needed()
+        if not self._access_token:
+            raise AtlassianAuthError("No access token available")
+        return AuthHeaders(
+            headers={
+                "Authorization": f"Bearer {self._access_token}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+            auth_method=AuthMethod.OAUTH2,
+            expires_at=self._expires_at,
+        )
+
+    async def is_token_valid(self) -> bool:
+        if not self._access_token:
+            return False
+        if self._expires_at is None:
+            return True  # Unknown expiry — assume valid
+        return time.time() < self._expires_at
+
+    async def refresh_if_needed(self) -> None:
+        """Proactively refresh the access token if it expires within the buffer window."""
+        if await self.is_token_valid():
+            # Still valid and not close to expiry
+            if self._expires_at is None or (self._expires_at - time.time()) > EXPIRY_BUFFER_SECONDS:
+                return
+
+        if not self._refresh_token:
+            logger.warning("Access token expired and no refresh token available")
+            return
+
+        async with self._refresh_lock:
+            # Double-check after acquiring lock (another coroutine may have refreshed)
+            if self._expires_at and (self._expires_at - time.time()) > EXPIRY_BUFFER_SECONDS:
+                return
+            await self._do_refresh()
+
+    async def _do_refresh(self) -> None:
+        logger.info("Refreshing OAuth2 access token")
+        payload = {
+            "grant_type": "refresh_token",
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "refresh_token": self._refresh_token,
+        }
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(TOKEN_URL, json=payload) as resp:
+                    if resp.status != 200:
+                        body = await resp.text()
+                        raise AtlassianAuthError(
+                            f"Token refresh failed (HTTP {resp.status}): {body[:300]}"
+                        )
+                    data = await resp.json()
+
+            self._access_token = data["access_token"]
+            if "refresh_token" in data:
+                self._refresh_token = data["refresh_token"]
+            expires_in = data.get("expires_in", 3600)
+            self._expires_at = time.time() + expires_in
+            logger.info("OAuth2 token refreshed, expires in %ds", expires_in)
+        except AtlassianAuthError:
+            raise
+        except Exception as e:
+            raise AtlassianAuthError(f"Token refresh error: {e}") from e
+
+    async def health_check(self) -> AuthHealthStatus:
+        start = time.time()
+        try:
+            auth = await self.get_auth_headers()
+            async with aiohttp.ClientSession() as session:
+                url = f"{self.base_url}/wiki/rest/api/space?limit=1"
+                async with session.get(url, headers=auth.headers) as resp:
+                    elapsed = (time.time() - start) * 1000
+                    if resp.status == 200:
+                        return AuthHealthStatus(
+                            is_healthy=True,
+                            auth_method=AuthMethod.OAUTH2.value,
+                            deployment_type="cloud",
+                            response_time_ms=elapsed,
+                        )
+                    body = await resp.text()
+                    return AuthHealthStatus(
+                        is_healthy=False,
+                        auth_method=AuthMethod.OAUTH2.value,
+                        deployment_type="cloud",
+                        response_time_ms=elapsed,
+                        error_message=f"HTTP {resp.status}: {body[:200]}",
+                    )
+        except Exception as e:
+            elapsed = (time.time() - start) * 1000
+            return AuthHealthStatus(
+                is_healthy=False,
+                auth_method=AuthMethod.OAUTH2.value,
+                deployment_type="cloud",
+                response_time_ms=elapsed,
+                error_message=str(e),
+            )

--- a/src/atlassian/auth/pat_auth.py
+++ b/src/atlassian/auth/pat_auth.py
@@ -1,0 +1,78 @@
+"""Personal Access Token (PAT) authentication for Atlassian On-Prem / Data Center"""
+
+import logging
+import time
+from typing import Dict, Any
+
+import aiohttp
+
+from ..base import AuthHeaders, AuthHealthStatus, AuthMethod, AtlassianConfigError
+from .base_auth import AtlassianAuthProvider
+
+logger = logging.getLogger(__name__)
+
+
+class PATAuthProvider(AtlassianAuthProvider):
+    """PAT Auth for On-Prem/DC: ``Authorization: Bearer {pat}``"""
+
+    def __init__(self, config: Dict[str, Any]):
+        super().__init__(config)
+        self.pat = config["pat"]
+        self.base_url = config["base_url"]
+
+    def _validate_config(self) -> None:
+        if not self.config.get("pat"):
+            raise AtlassianConfigError(
+                "PATAuthProvider missing required config: pat"
+            )
+        if not self.config.get("base_url"):
+            raise AtlassianConfigError(
+                "PATAuthProvider missing required config: base_url"
+            )
+
+    async def get_auth_headers(self) -> AuthHeaders:
+        return AuthHeaders(
+            headers={
+                "Authorization": f"Bearer {self.pat}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+            auth_method=AuthMethod.PAT,
+        )
+
+    async def is_token_valid(self) -> bool:
+        # PATs do not self-expire (admin can revoke them server-side)
+        return True
+
+    async def health_check(self) -> AuthHealthStatus:
+        start = time.time()
+        try:
+            auth = await self.get_auth_headers()
+            async with aiohttp.ClientSession() as session:
+                url = f"{self.base_url}/rest/api/space?limit=1"
+                async with session.get(url, headers=auth.headers) as resp:
+                    elapsed = (time.time() - start) * 1000
+                    if resp.status == 200:
+                        return AuthHealthStatus(
+                            is_healthy=True,
+                            auth_method=AuthMethod.PAT.value,
+                            deployment_type="on_prem",
+                            response_time_ms=elapsed,
+                        )
+                    body = await resp.text()
+                    return AuthHealthStatus(
+                        is_healthy=False,
+                        auth_method=AuthMethod.PAT.value,
+                        deployment_type="on_prem",
+                        response_time_ms=elapsed,
+                        error_message=f"HTTP {resp.status}: {body[:200]}",
+                    )
+        except Exception as e:
+            elapsed = (time.time() - start) * 1000
+            return AuthHealthStatus(
+                is_healthy=False,
+                auth_method=AuthMethod.PAT.value,
+                deployment_type="on_prem",
+                response_time_ms=elapsed,
+                error_message=str(e),
+            )

--- a/src/atlassian/base.py
+++ b/src/atlassian/base.py
@@ -1,0 +1,75 @@
+"""Base types, enums, dataclasses, and exceptions for Atlassian integration"""
+
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class DeploymentType(Enum):
+    """Atlassian deployment types"""
+    CLOUD = "cloud"
+    ON_PREM = "on_prem"
+    DATA_CENTER = "data_center"
+
+
+class AuthMethod(Enum):
+    """Supported authentication methods"""
+    BASIC = "basic"
+    PAT = "pat"
+    OAUTH2 = "oauth2"
+
+
+@dataclass
+class AuthHeaders:
+    """Authentication headers for Atlassian API requests"""
+    headers: Dict[str, str]
+    auth_method: AuthMethod
+    expires_at: Optional[float] = None
+
+
+@dataclass
+class AuthHealthStatus:
+    """Health check status for Atlassian authentication"""
+    is_healthy: bool
+    auth_method: str
+    deployment_type: str
+    response_time_ms: float
+    error_message: Optional[str] = None
+    metadata: Optional[Dict] = field(default_factory=dict)
+
+
+# --- Exceptions ---
+
+class AtlassianError(Exception):
+    """Base exception for all Atlassian-related errors"""
+    pass
+
+
+class AtlassianAuthError(AtlassianError):
+    """Authentication failure (invalid credentials, expired token, etc.)"""
+    pass
+
+
+class AtlassianConfigError(AtlassianError):
+    """Configuration validation error"""
+    pass
+
+
+class AtlassianAPIError(AtlassianError):
+    """Atlassian REST API error"""
+
+    def __init__(self, message: str, status_code: Optional[int] = None, response_body: Optional[str] = None):
+        super().__init__(message)
+        self.status_code = status_code
+        self.response_body = response_body
+
+
+class AtlassianRateLimitError(AtlassianAPIError):
+    """Rate limit exceeded (HTTP 429)"""
+
+    def __init__(self, message: str, retry_after: Optional[float] = None, **kwargs):
+        super().__init__(message, **kwargs)
+        self.retry_after = retry_after

--- a/src/atlassian/config.py
+++ b/src/atlassian/config.py
@@ -1,0 +1,199 @@
+"""Configuration management for Atlassian / Confluence integration"""
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Dict, Any, Optional
+
+from .base import AuthMethod, DeploymentType, AtlassianConfigError
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ConfluenceConfig:
+    """Confluence connection configuration.
+
+    Use ``ConfluenceConfig.from_env()`` to create an instance from environment
+    variables. Explicit env vars always override auto-detection.
+    """
+
+    base_url: str
+    deployment_type: DeploymentType
+    auth_method: AuthMethod
+    auth_config: Dict[str, Any] = field(default_factory=dict)
+
+    # SSL
+    ssl_verify: bool = True
+    ca_bundle: Optional[str] = None
+
+    # Timeouts
+    timeout: float = 30.0
+    connect_timeout: float = 10.0
+    pool_size: int = 10
+
+    # Rate-limit / retry
+    max_retries: int = 3
+
+    @classmethod
+    def from_env(cls) -> "ConfluenceConfig":
+        """Build configuration from ``CONFLUENCE_*`` environment variables.
+
+        Raises:
+            AtlassianConfigError: on invalid / missing configuration.
+        """
+        base_url = os.getenv("CONFLUENCE_URL", "").rstrip("/")
+        if not base_url:
+            raise AtlassianConfigError("CONFLUENCE_URL is required")
+        if not base_url.startswith(("http://", "https://")):
+            raise AtlassianConfigError(
+                "CONFLUENCE_URL must start with http:// or https://"
+            )
+
+        deployment_type = cls._resolve_deployment_type(base_url)
+        auth_method = cls._resolve_auth_method(deployment_type)
+        auth_config = cls._build_auth_config(auth_method, base_url)
+
+        # SSL
+        ssl_verify = os.getenv("CONFLUENCE_SSL_VERIFY", "true").lower() == "true"
+        ca_bundle = os.getenv("CONFLUENCE_CA_BUNDLE")
+        if ca_bundle and not os.path.isfile(ca_bundle):
+            raise AtlassianConfigError(
+                f"CA bundle file not found: {ca_bundle}"
+            )
+
+        # Timeouts / pool
+        timeout = float(os.getenv("CONFLUENCE_TIMEOUT", "30.0"))
+        connect_timeout = float(os.getenv("CONFLUENCE_CONNECT_TIMEOUT", "10.0"))
+        pool_size = int(os.getenv("CONFLUENCE_POOL_SIZE", "10"))
+        max_retries = int(os.getenv("CONFLUENCE_MAX_RETRIES", "3"))
+
+        config = cls(
+            base_url=base_url,
+            deployment_type=deployment_type,
+            auth_method=auth_method,
+            auth_config=auth_config,
+            ssl_verify=ssl_verify,
+            ca_bundle=ca_bundle,
+            timeout=timeout,
+            connect_timeout=connect_timeout,
+            pool_size=pool_size,
+            max_retries=max_retries,
+        )
+        config._validate()
+        return config
+
+    # ------------------------------------------------------------------
+    # Detection helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _resolve_deployment_type(url: str) -> DeploymentType:
+        explicit = os.getenv("CONFLUENCE_DEPLOYMENT_TYPE", "").lower()
+        if explicit:
+            try:
+                return DeploymentType(explicit)
+            except ValueError:
+                valid = [d.value for d in DeploymentType]
+                raise AtlassianConfigError(
+                    f"Invalid CONFLUENCE_DEPLOYMENT_TYPE='{explicit}'. Valid: {valid}"
+                )
+        # Auto-detect
+        if ".atlassian.net" in url:
+            return DeploymentType.CLOUD
+        return DeploymentType.ON_PREM
+
+    @staticmethod
+    def _resolve_auth_method(deployment_type: DeploymentType) -> AuthMethod:
+        explicit = os.getenv("CONFLUENCE_AUTH_METHOD", "").lower()
+        if explicit:
+            try:
+                return AuthMethod(explicit)
+            except ValueError:
+                valid = [a.value for a in AuthMethod]
+                raise AtlassianConfigError(
+                    f"Invalid CONFLUENCE_AUTH_METHOD='{explicit}'. Valid: {valid}"
+                )
+
+        # Auto-detect: OAuth2 > PAT > Basic
+        if os.getenv("CONFLUENCE_OAUTH2_CLIENT_ID"):
+            method = AuthMethod.OAUTH2
+        elif os.getenv("CONFLUENCE_PAT") or os.getenv("CONFLUENCE_API_TOKEN"):
+            if deployment_type == DeploymentType.CLOUD:
+                # On Cloud with only a token, assume Basic (email+token)
+                if os.getenv("CONFLUENCE_USERNAME"):
+                    method = AuthMethod.BASIC
+                else:
+                    method = AuthMethod.PAT
+            else:
+                method = AuthMethod.PAT
+        elif os.getenv("CONFLUENCE_USERNAME"):
+            method = AuthMethod.BASIC
+        else:
+            raise AtlassianConfigError(
+                "Cannot auto-detect auth method. Set CONFLUENCE_AUTH_METHOD or "
+                "provide credentials via CONFLUENCE_USERNAME/CONFLUENCE_API_TOKEN, "
+                "CONFLUENCE_PAT, or CONFLUENCE_OAUTH2_CLIENT_ID."
+            )
+        return method
+
+    @staticmethod
+    def _build_auth_config(auth_method: AuthMethod, base_url: str) -> Dict[str, Any]:
+        cfg: Dict[str, Any] = {"base_url": base_url}
+
+        if auth_method == AuthMethod.BASIC:
+            cfg["username"] = os.getenv("CONFLUENCE_USERNAME", "")
+            cfg["api_token"] = os.getenv("CONFLUENCE_API_TOKEN", "")
+
+        elif auth_method == AuthMethod.PAT:
+            cfg["pat"] = os.getenv("CONFLUENCE_PAT") or os.getenv("CONFLUENCE_API_TOKEN", "")
+
+        elif auth_method == AuthMethod.OAUTH2:
+            cfg["oauth2_client_id"] = os.getenv("CONFLUENCE_OAUTH2_CLIENT_ID", "")
+            cfg["oauth2_client_secret"] = os.getenv("CONFLUENCE_OAUTH2_CLIENT_SECRET", "")
+            cfg["oauth2_access_token"] = os.getenv("CONFLUENCE_OAUTH2_ACCESS_TOKEN")
+            cfg["oauth2_refresh_token"] = os.getenv("CONFLUENCE_OAUTH2_REFRESH_TOKEN")
+            cfg["oauth2_token_expires_at"] = os.getenv("CONFLUENCE_OAUTH2_TOKEN_EXPIRES_AT")
+            cfg["cloud_id"] = os.getenv("CONFLUENCE_CLOUD_ID")
+
+        return cfg
+
+    # ------------------------------------------------------------------
+    # Cross-field validation
+    # ------------------------------------------------------------------
+
+    def _validate(self) -> None:
+        if self.auth_method == AuthMethod.OAUTH2 and self.deployment_type != DeploymentType.CLOUD:
+            raise AtlassianConfigError(
+                "OAuth2 is only supported for Atlassian Cloud deployments"
+            )
+
+        if self.auth_method == AuthMethod.BASIC:
+            if not self.auth_config.get("username"):
+                raise AtlassianConfigError("CONFLUENCE_USERNAME is required for Basic auth")
+            if not self.auth_config.get("api_token"):
+                raise AtlassianConfigError("CONFLUENCE_API_TOKEN is required for Basic auth")
+
+        elif self.auth_method == AuthMethod.PAT:
+            if not self.auth_config.get("pat"):
+                raise AtlassianConfigError(
+                    "CONFLUENCE_PAT or CONFLUENCE_API_TOKEN is required for PAT auth"
+                )
+
+        elif self.auth_method == AuthMethod.OAUTH2:
+            if not self.auth_config.get("oauth2_client_id"):
+                raise AtlassianConfigError("CONFLUENCE_OAUTH2_CLIENT_ID is required")
+            if not self.auth_config.get("oauth2_client_secret"):
+                raise AtlassianConfigError("CONFLUENCE_OAUTH2_CLIENT_SECRET is required")
+            if not self.auth_config.get("oauth2_access_token") and not self.auth_config.get("oauth2_refresh_token"):
+                raise AtlassianConfigError(
+                    "At least CONFLUENCE_OAUTH2_ACCESS_TOKEN or "
+                    "CONFLUENCE_OAUTH2_REFRESH_TOKEN is required"
+                )
+
+        if self.timeout <= 0:
+            raise AtlassianConfigError("CONFLUENCE_TIMEOUT must be positive")
+        if self.connect_timeout <= 0:
+            raise AtlassianConfigError("CONFLUENCE_CONNECT_TIMEOUT must be positive")
+        if self.pool_size <= 0:
+            raise AtlassianConfigError("CONFLUENCE_POOL_SIZE must be positive")

--- a/src/atlassian/factory.py
+++ b/src/atlassian/factory.py
@@ -1,0 +1,83 @@
+"""Factory for creating Atlassian auth providers and HTTP clients"""
+
+import logging
+from typing import Dict, Type
+
+from .auth.base_auth import AtlassianAuthProvider
+from .auth.basic_auth import BasicAuthProvider
+from .auth.pat_auth import PATAuthProvider
+from .auth.oauth2_auth import OAuth2AuthProvider
+from .base import AuthMethod, AtlassianConfigError
+from .config import ConfluenceConfig
+from .http_client import AtlassianHTTPClient
+
+logger = logging.getLogger(__name__)
+
+
+class AtlassianAuthFactory:
+    """Registry-based factory for auth providers and convenience HTTP client creation.
+
+    Follows the pattern from ``src/ai_providers/factory.py``.
+    """
+
+    _auth_providers: Dict[AuthMethod, Type[AtlassianAuthProvider]] = {}
+
+    @classmethod
+    def register_auth_provider(
+        cls,
+        method: AuthMethod,
+        provider_class: Type[AtlassianAuthProvider],
+    ) -> None:
+        if not issubclass(provider_class, AtlassianAuthProvider):
+            raise ValueError("provider_class must be a subclass of AtlassianAuthProvider")
+        cls._auth_providers[method] = provider_class
+        logger.info("Registered Atlassian auth provider: %s", method.value)
+
+    @classmethod
+    def create_auth_provider(cls, config: ConfluenceConfig) -> AtlassianAuthProvider:
+        """Create the appropriate auth provider from a ``ConfluenceConfig``."""
+        provider_cls = cls._auth_providers.get(config.auth_method)
+        if provider_cls is None:
+            available = [m.value for m in cls._auth_providers]
+            raise AtlassianConfigError(
+                f"No auth provider registered for method '{config.auth_method.value}'. "
+                f"Available: {available}"
+            )
+        return provider_cls(config.auth_config)
+
+    @classmethod
+    def create_http_client(cls, config: ConfluenceConfig) -> AtlassianHTTPClient:
+        """Convenience: config → auth provider → HTTP client."""
+        auth = cls.create_auth_provider(config)
+        return AtlassianHTTPClient(
+            auth_provider=auth,
+            base_url=config.base_url,
+            timeout=config.timeout,
+            connect_timeout=config.connect_timeout,
+            pool_size=config.pool_size,
+            max_retries=config.max_retries,
+            ssl_verify=config.ssl_verify,
+            ca_bundle=config.ca_bundle,
+        )
+
+    @classmethod
+    def list_registered(cls) -> list:
+        return [m.value for m in cls._auth_providers]
+
+    @classmethod
+    def clear_registry(cls) -> None:
+        cls._auth_providers.clear()
+
+
+def _register_providers() -> None:
+    """Register built-in auth providers at module import time."""
+    AtlassianAuthFactory.register_auth_provider(AuthMethod.BASIC, BasicAuthProvider)
+    AtlassianAuthFactory.register_auth_provider(AuthMethod.PAT, PATAuthProvider)
+    AtlassianAuthFactory.register_auth_provider(AuthMethod.OAUTH2, OAuth2AuthProvider)
+    logger.info(
+        "Atlassian auth provider registration complete. Available: %s",
+        AtlassianAuthFactory.list_registered(),
+    )
+
+
+_register_providers()

--- a/src/atlassian/http_client.py
+++ b/src/atlassian/http_client.py
@@ -1,0 +1,229 @@
+"""HTTP client for Atlassian APIs with retry, rate-limit, and auth injection"""
+
+import asyncio
+import logging
+import ssl
+import time
+from typing import Any, Dict, Optional
+
+import aiohttp
+from aiohttp import ClientSession, ClientTimeout, TCPConnector
+
+from .auth.base_auth import AtlassianAuthProvider
+from .base import (
+    AtlassianAPIError,
+    AtlassianAuthError,
+    AtlassianRateLimitError,
+)
+
+logger = logging.getLogger(__name__)
+
+RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
+
+
+class AtlassianHTTPClient:
+    """Async HTTP client that injects auth headers and handles retries.
+
+    Follows aiohttp patterns from ``src/ai_providers/providers/ollama_provider.py``.
+    """
+
+    def __init__(
+        self,
+        auth_provider: AtlassianAuthProvider,
+        base_url: str,
+        *,
+        timeout: float = 30.0,
+        connect_timeout: float = 10.0,
+        pool_size: int = 10,
+        max_retries: int = 3,
+        ssl_verify: bool = True,
+        ca_bundle: Optional[str] = None,
+    ):
+        self.auth_provider = auth_provider
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self.connect_timeout = connect_timeout
+        self.pool_size = pool_size
+        self.max_retries = max_retries
+        self.ssl_verify = ssl_verify
+        self.ca_bundle = ca_bundle
+
+        self._session: Optional[ClientSession] = None
+        self._ssl_context: Optional[ssl.SSLContext] = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def initialize(self) -> None:
+        """Create the ``aiohttp.ClientSession`` and SSL context."""
+        self._ssl_context = self._build_ssl_context()
+        connector = TCPConnector(
+            limit=self.pool_size,
+            ssl=self._ssl_context,
+        )
+        client_timeout = ClientTimeout(
+            total=self.timeout,
+            connect=self.connect_timeout,
+        )
+        self._session = ClientSession(
+            timeout=client_timeout,
+            connector=connector,
+        )
+        await self.auth_provider.initialize()
+        logger.info("AtlassianHTTPClient initialized (base_url=%s)", self.base_url)
+
+    async def close(self) -> None:
+        """Close session and auth provider."""
+        if self._session:
+            await self._session.close()
+            self._session = None
+        await self.auth_provider.close()
+        logger.info("AtlassianHTTPClient closed")
+
+    # ------------------------------------------------------------------
+    # Public request API
+    # ------------------------------------------------------------------
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        json: Optional[Any] = None,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
+        """Send an authenticated request with retry logic.
+
+        Args:
+            method: HTTP method (GET, POST, …).
+            path: API path appended to ``base_url``.
+            params: Query parameters.
+            json: JSON body.
+            headers: Extra headers (merged with auth headers).
+
+        Returns:
+            Parsed JSON response body.
+
+        Raises:
+            AtlassianAuthError: On 401 after one retry with refreshed token.
+            AtlassianRateLimitError: On 429 after retries exhausted.
+            AtlassianAPIError: On other non-recoverable HTTP errors.
+        """
+        if not self._session:
+            raise RuntimeError("Client not initialized. Call initialize() first.")
+
+        url = f"{self.base_url}{path}"
+        retry_delay = 1.0
+        auth_retried = False
+
+        for attempt in range(self.max_retries + 1):
+            auth = await self.auth_provider.get_auth_headers()
+            merged_headers = {**auth.headers, **(headers or {})}
+
+            self._log_request(method, url, attempt)
+
+            try:
+                async with self._session.request(
+                    method, url, params=params, json=json, headers=merged_headers
+                ) as resp:
+                    status = resp.status
+
+                    if 200 <= status < 300:
+                        if resp.content_type and "json" in resp.content_type:
+                            return await resp.json()
+                        text = await resp.text()
+                        return {"_raw": text}
+
+                    body = await resp.text()
+
+                    # 401 — force refresh once then retry
+                    if status == 401 and not auth_retried:
+                        auth_retried = True
+                        logger.warning("Got 401, forcing token refresh and retrying")
+                        await self.auth_provider.refresh_if_needed()
+                        continue
+
+                    if status == 401:
+                        raise AtlassianAuthError(
+                            f"Authentication failed after refresh (HTTP 401): {body[:300]}"
+                        )
+
+                    # 429 — respect Retry-After
+                    if status == 429:
+                        retry_after = self._parse_retry_after(resp)
+                        if attempt < self.max_retries:
+                            wait = retry_after or retry_delay
+                            logger.warning(
+                                "Rate limited (429). Waiting %.1fs (attempt %d/%d)",
+                                wait, attempt + 1, self.max_retries + 1,
+                            )
+                            await asyncio.sleep(wait)
+                            retry_delay = min(retry_delay * 2, 60.0)
+                            continue
+                        raise AtlassianRateLimitError(
+                            f"Rate limit exceeded after {self.max_retries + 1} attempts",
+                            retry_after=retry_after,
+                            status_code=429,
+                            response_body=body[:500],
+                        )
+
+                    # Retryable server errors
+                    if status in RETRYABLE_STATUS_CODES and attempt < self.max_retries:
+                        logger.warning(
+                            "Retryable error %d on %s (attempt %d/%d). Retrying in %.1fs",
+                            status, path, attempt + 1, self.max_retries + 1, retry_delay,
+                        )
+                        await asyncio.sleep(retry_delay)
+                        retry_delay = min(retry_delay * 2, 60.0)
+                        continue
+
+                    raise AtlassianAPIError(
+                        f"HTTP {status}: {body[:500]}",
+                        status_code=status,
+                        response_body=body[:1000],
+                    )
+
+            except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+                if attempt < self.max_retries:
+                    logger.warning(
+                        "Connection error on %s (attempt %d/%d): %s. Retrying in %.1fs",
+                        path, attempt + 1, self.max_retries + 1, e, retry_delay,
+                    )
+                    await asyncio.sleep(retry_delay)
+                    retry_delay = min(retry_delay * 2, 60.0)
+                    continue
+                raise AtlassianAPIError(f"Connection failed after retries: {e}") from e
+
+        # Should not reach here, but just in case
+        raise AtlassianAPIError("Request failed after all retries")
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _build_ssl_context(self) -> Optional[ssl.SSLContext]:
+        if not self.ssl_verify:
+            ctx = ssl.create_default_context()
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+            return ctx
+        if self.ca_bundle:
+            ctx = ssl.create_default_context(cafile=self.ca_bundle)
+            return ctx
+        return None  # aiohttp uses default system certs
+
+    @staticmethod
+    def _parse_retry_after(resp: aiohttp.ClientResponse) -> Optional[float]:
+        raw = resp.headers.get("Retry-After")
+        if raw is None:
+            return None
+        try:
+            return float(raw)
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _log_request(method: str, url: str, attempt: int) -> None:
+        logger.debug("→ %s %s (attempt %d)", method, url, attempt + 1)

--- a/tests/test_atlassian/test_base.py
+++ b/tests/test_atlassian/test_base.py
@@ -1,0 +1,85 @@
+"""Tests for src/atlassian/base.py — enums, dataclasses, exceptions"""
+
+import pytest
+
+from src.atlassian.base import (
+    AuthHeaders,
+    AuthHealthStatus,
+    AuthMethod,
+    AtlassianAPIError,
+    AtlassianAuthError,
+    AtlassianConfigError,
+    AtlassianError,
+    AtlassianRateLimitError,
+    DeploymentType,
+)
+
+
+class TestEnums:
+    def test_deployment_type_values(self):
+        assert DeploymentType.CLOUD.value == "cloud"
+        assert DeploymentType.ON_PREM.value == "on_prem"
+        assert DeploymentType.DATA_CENTER.value == "data_center"
+
+    def test_auth_method_values(self):
+        assert AuthMethod.BASIC.value == "basic"
+        assert AuthMethod.PAT.value == "pat"
+        assert AuthMethod.OAUTH2.value == "oauth2"
+
+
+class TestAuthHeaders:
+    def test_creation(self):
+        ah = AuthHeaders(
+            headers={"Authorization": "Basic abc"},
+            auth_method=AuthMethod.BASIC,
+        )
+        assert ah.headers["Authorization"] == "Basic abc"
+        assert ah.auth_method == AuthMethod.BASIC
+        assert ah.expires_at is None
+
+    def test_with_expiry(self):
+        ah = AuthHeaders(
+            headers={}, auth_method=AuthMethod.OAUTH2, expires_at=99999.0
+        )
+        assert ah.expires_at == 99999.0
+
+
+class TestAuthHealthStatus:
+    def test_healthy(self):
+        s = AuthHealthStatus(
+            is_healthy=True,
+            auth_method="basic",
+            deployment_type="cloud",
+            response_time_ms=42.0,
+        )
+        assert s.is_healthy
+        assert s.error_message is None
+
+    def test_unhealthy(self):
+        s = AuthHealthStatus(
+            is_healthy=False,
+            auth_method="pat",
+            deployment_type="on_prem",
+            response_time_ms=100.0,
+            error_message="timeout",
+        )
+        assert not s.is_healthy
+        assert s.error_message == "timeout"
+
+
+class TestExceptions:
+    def test_hierarchy(self):
+        assert issubclass(AtlassianAuthError, AtlassianError)
+        assert issubclass(AtlassianConfigError, AtlassianError)
+        assert issubclass(AtlassianAPIError, AtlassianError)
+        assert issubclass(AtlassianRateLimitError, AtlassianAPIError)
+
+    def test_api_error_attrs(self):
+        e = AtlassianAPIError("fail", status_code=500, response_body="err")
+        assert e.status_code == 500
+        assert e.response_body == "err"
+
+    def test_rate_limit_attrs(self):
+        e = AtlassianRateLimitError("slow", retry_after=30.0, status_code=429)
+        assert e.retry_after == 30.0
+        assert e.status_code == 429

--- a/tests/test_atlassian/test_basic_auth.py
+++ b/tests/test_atlassian/test_basic_auth.py
@@ -1,0 +1,91 @@
+"""Tests for BasicAuthProvider"""
+
+import base64
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from src.atlassian.auth.basic_auth import BasicAuthProvider
+from src.atlassian.base import AuthMethod, AtlassianConfigError
+
+
+def _config(overrides=None):
+    cfg = {
+        "username": "user@example.com",
+        "api_token": "my-api-token",
+        "base_url": "https://myorg.atlassian.net",
+    }
+    if overrides:
+        cfg.update(overrides)
+    return cfg
+
+
+class TestValidation:
+    def test_valid(self):
+        p = BasicAuthProvider(_config())
+        assert p.username == "user@example.com"
+
+    def test_missing_username(self):
+        with pytest.raises(AtlassianConfigError, match="username"):
+            BasicAuthProvider(_config({"username": ""}))
+
+    def test_missing_api_token(self):
+        with pytest.raises(AtlassianConfigError, match="api_token"):
+            BasicAuthProvider(_config({"api_token": ""}))
+
+    def test_missing_base_url(self):
+        with pytest.raises(AtlassianConfigError, match="base_url"):
+            BasicAuthProvider(_config({"base_url": ""}))
+
+
+class TestHeaders:
+    @pytest.mark.asyncio
+    async def test_auth_header_format(self):
+        p = BasicAuthProvider(_config())
+        auth = await p.get_auth_headers()
+        expected = base64.b64encode(b"user@example.com:my-api-token").decode()
+        assert auth.headers["Authorization"] == f"Basic {expected}"
+        assert auth.auth_method == AuthMethod.BASIC
+
+    @pytest.mark.asyncio
+    async def test_token_always_valid(self):
+        p = BasicAuthProvider(_config())
+        assert await p.is_token_valid() is True
+
+
+class TestHealthCheck:
+    @pytest.mark.asyncio
+    async def test_healthy(self):
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("src.atlassian.auth.basic_auth.aiohttp.ClientSession", return_value=mock_session):
+            p = BasicAuthProvider(_config())
+            health = await p.health_check()
+            assert health.is_healthy
+            assert health.auth_method == "basic"
+
+    @pytest.mark.asyncio
+    async def test_unhealthy(self):
+        mock_resp = AsyncMock()
+        mock_resp.status = 401
+        mock_resp.text = AsyncMock(return_value="Unauthorized")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("src.atlassian.auth.basic_auth.aiohttp.ClientSession", return_value=mock_session):
+            p = BasicAuthProvider(_config())
+            health = await p.health_check()
+            assert not health.is_healthy
+            assert "401" in health.error_message

--- a/tests/test_atlassian/test_config.py
+++ b/tests/test_atlassian/test_config.py
@@ -1,0 +1,120 @@
+"""Tests for src/atlassian/config.py — ConfluenceConfig.from_env()"""
+
+import os
+import pytest
+
+from src.atlassian.base import AuthMethod, DeploymentType, AtlassianConfigError
+from src.atlassian.config import ConfluenceConfig
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Remove all CONFLUENCE_* env vars before each test."""
+    for key in list(os.environ):
+        if key.startswith("CONFLUENCE_"):
+            monkeypatch.delenv(key, raising=False)
+
+
+class TestDeploymentDetection:
+    def test_cloud_auto_detect(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_URL", "https://myorg.atlassian.net")
+        monkeypatch.setenv("CONFLUENCE_USERNAME", "user@example.com")
+        monkeypatch.setenv("CONFLUENCE_API_TOKEN", "tok")
+        cfg = ConfluenceConfig.from_env()
+        assert cfg.deployment_type == DeploymentType.CLOUD
+
+    def test_on_prem_auto_detect(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_URL", "https://confluence.corp.local")
+        monkeypatch.setenv("CONFLUENCE_PAT", "mypat")
+        cfg = ConfluenceConfig.from_env()
+        assert cfg.deployment_type == DeploymentType.ON_PREM
+
+    def test_explicit_deployment_type(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_URL", "https://myorg.atlassian.net")
+        monkeypatch.setenv("CONFLUENCE_DEPLOYMENT_TYPE", "data_center")
+        monkeypatch.setenv("CONFLUENCE_PAT", "tok")
+        cfg = ConfluenceConfig.from_env()
+        assert cfg.deployment_type == DeploymentType.DATA_CENTER
+
+    def test_invalid_deployment_type(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_URL", "https://x.atlassian.net")
+        monkeypatch.setenv("CONFLUENCE_DEPLOYMENT_TYPE", "invalid")
+        with pytest.raises(AtlassianConfigError, match="Invalid CONFLUENCE_DEPLOYMENT_TYPE"):
+            ConfluenceConfig.from_env()
+
+
+class TestAuthMethodDetection:
+    def test_basic_auth(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_URL", "https://x.atlassian.net")
+        monkeypatch.setenv("CONFLUENCE_USERNAME", "u")
+        monkeypatch.setenv("CONFLUENCE_API_TOKEN", "t")
+        cfg = ConfluenceConfig.from_env()
+        assert cfg.auth_method == AuthMethod.BASIC
+
+    def test_pat_auth(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_URL", "https://confluence.corp.local")
+        monkeypatch.setenv("CONFLUENCE_PAT", "mypat")
+        cfg = ConfluenceConfig.from_env()
+        assert cfg.auth_method == AuthMethod.PAT
+
+    def test_oauth2_auth(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_URL", "https://x.atlassian.net")
+        monkeypatch.setenv("CONFLUENCE_OAUTH2_CLIENT_ID", "cid")
+        monkeypatch.setenv("CONFLUENCE_OAUTH2_CLIENT_SECRET", "sec")
+        monkeypatch.setenv("CONFLUENCE_OAUTH2_ACCESS_TOKEN", "at")
+        cfg = ConfluenceConfig.from_env()
+        assert cfg.auth_method == AuthMethod.OAUTH2
+
+    def test_explicit_auth_method(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_URL", "https://x.atlassian.net")
+        monkeypatch.setenv("CONFLUENCE_AUTH_METHOD", "pat")
+        monkeypatch.setenv("CONFLUENCE_PAT", "mypat")
+        cfg = ConfluenceConfig.from_env()
+        assert cfg.auth_method == AuthMethod.PAT
+
+    def test_no_credentials_raises(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_URL", "https://x.atlassian.net")
+        with pytest.raises(AtlassianConfigError, match="Cannot auto-detect"):
+            ConfluenceConfig.from_env()
+
+
+class TestValidation:
+    def test_missing_url(self, monkeypatch):
+        with pytest.raises(AtlassianConfigError, match="CONFLUENCE_URL is required"):
+            ConfluenceConfig.from_env()
+
+    def test_invalid_url_scheme(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_URL", "ftp://bad")
+        with pytest.raises(AtlassianConfigError, match="must start with http"):
+            ConfluenceConfig.from_env()
+
+    def test_oauth2_on_prem_rejected(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_URL", "https://confluence.corp.local")
+        monkeypatch.setenv("CONFLUENCE_AUTH_METHOD", "oauth2")
+        monkeypatch.setenv("CONFLUENCE_OAUTH2_CLIENT_ID", "cid")
+        monkeypatch.setenv("CONFLUENCE_OAUTH2_CLIENT_SECRET", "sec")
+        monkeypatch.setenv("CONFLUENCE_OAUTH2_ACCESS_TOKEN", "at")
+        with pytest.raises(AtlassianConfigError, match="OAuth2 is only supported"):
+            ConfluenceConfig.from_env()
+
+    def test_basic_missing_username(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_URL", "https://x.atlassian.net")
+        monkeypatch.setenv("CONFLUENCE_AUTH_METHOD", "basic")
+        monkeypatch.setenv("CONFLUENCE_API_TOKEN", "tok")
+        with pytest.raises(AtlassianConfigError, match="CONFLUENCE_USERNAME"):
+            ConfluenceConfig.from_env()
+
+    def test_ca_bundle_not_found(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_URL", "https://x.atlassian.net")
+        monkeypatch.setenv("CONFLUENCE_USERNAME", "u")
+        monkeypatch.setenv("CONFLUENCE_API_TOKEN", "t")
+        monkeypatch.setenv("CONFLUENCE_CA_BUNDLE", "/nonexistent/cert.pem")
+        with pytest.raises(AtlassianConfigError, match="CA bundle file not found"):
+            ConfluenceConfig.from_env()
+
+    def test_url_trailing_slash_stripped(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_URL", "https://x.atlassian.net/")
+        monkeypatch.setenv("CONFLUENCE_USERNAME", "u")
+        monkeypatch.setenv("CONFLUENCE_API_TOKEN", "t")
+        cfg = ConfluenceConfig.from_env()
+        assert not cfg.base_url.endswith("/")

--- a/tests/test_atlassian/test_factory.py
+++ b/tests/test_atlassian/test_factory.py
@@ -1,0 +1,74 @@
+"""Tests for AtlassianAuthFactory"""
+
+import pytest
+
+from src.atlassian.base import AuthMethod, AtlassianConfigError
+from src.atlassian.auth.basic_auth import BasicAuthProvider
+from src.atlassian.auth.pat_auth import PATAuthProvider
+from src.atlassian.auth.oauth2_auth import OAuth2AuthProvider
+from src.atlassian.config import ConfluenceConfig
+from src.atlassian.factory import AtlassianAuthFactory
+
+
+class TestRegistration:
+    def test_built_in_providers_registered(self):
+        registered = AtlassianAuthFactory.list_registered()
+        assert "basic" in registered
+        assert "pat" in registered
+        assert "oauth2" in registered
+
+    def test_create_basic_provider(self):
+        from src.atlassian.base import DeploymentType
+        config = ConfluenceConfig(
+            base_url="https://x.atlassian.net",
+            deployment_type=DeploymentType.CLOUD,
+            auth_method=AuthMethod.BASIC,
+            auth_config={
+                "username": "user@example.com",
+                "api_token": "tok",
+                "base_url": "https://x.atlassian.net",
+            },
+        )
+        provider = AtlassianAuthFactory.create_auth_provider(config)
+        assert isinstance(provider, BasicAuthProvider)
+
+    def test_create_pat_provider(self):
+        from src.atlassian.base import DeploymentType
+        config = ConfluenceConfig(
+            base_url="https://confluence.corp.local",
+            deployment_type=DeploymentType.ON_PREM,
+            auth_method=AuthMethod.PAT,
+            auth_config={
+                "pat": "my-pat",
+                "base_url": "https://confluence.corp.local",
+            },
+        )
+        provider = AtlassianAuthFactory.create_auth_provider(config)
+        assert isinstance(provider, PATAuthProvider)
+
+    def test_create_http_client(self):
+        from src.atlassian.base import DeploymentType
+        from src.atlassian.http_client import AtlassianHTTPClient
+        config = ConfluenceConfig(
+            base_url="https://confluence.corp.local",
+            deployment_type=DeploymentType.ON_PREM,
+            auth_method=AuthMethod.PAT,
+            auth_config={
+                "pat": "my-pat",
+                "base_url": "https://confluence.corp.local",
+            },
+        )
+        client = AtlassianAuthFactory.create_http_client(config)
+        assert isinstance(client, AtlassianHTTPClient)
+
+
+class TestClearRegistry:
+    def test_clear_and_re_register(self):
+        AtlassianAuthFactory.clear_registry()
+        assert AtlassianAuthFactory.list_registered() == []
+
+        # Re-register so other tests aren't affected
+        AtlassianAuthFactory.register_auth_provider(AuthMethod.BASIC, BasicAuthProvider)
+        AtlassianAuthFactory.register_auth_provider(AuthMethod.PAT, PATAuthProvider)
+        AtlassianAuthFactory.register_auth_provider(AuthMethod.OAUTH2, OAuth2AuthProvider)
+        assert len(AtlassianAuthFactory.list_registered()) == 3

--- a/tests/test_atlassian/test_http_client.py
+++ b/tests/test_atlassian/test_http_client.py
@@ -1,0 +1,192 @@
+"""Tests for AtlassianHTTPClient — retry, rate-limit, auth injection"""
+
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
+
+from src.atlassian.base import (
+    AuthHeaders,
+    AuthMethod,
+    AtlassianAPIError,
+    AtlassianAuthError,
+    AtlassianRateLimitError,
+)
+from src.atlassian.http_client import AtlassianHTTPClient
+
+
+def _mock_auth_provider():
+    provider = AsyncMock()
+    provider.get_auth_headers = AsyncMock(return_value=AuthHeaders(
+        headers={"Authorization": "Bearer test-token", "Content-Type": "application/json", "Accept": "application/json"},
+        auth_method=AuthMethod.PAT,
+    ))
+    provider.initialize = AsyncMock()
+    provider.close = AsyncMock()
+    provider.refresh_if_needed = AsyncMock()
+    return provider
+
+
+def _make_response(status, body=None, content_type="application/json", headers=None):
+    resp = AsyncMock()
+    resp.status = status
+    resp.content_type = content_type
+    resp.headers = headers or {}
+    if isinstance(body, dict):
+        resp.json = AsyncMock(return_value=body)
+    else:
+        resp.text = AsyncMock(return_value=body or "")
+        resp.json = AsyncMock(return_value={})
+    resp.__aenter__ = AsyncMock(return_value=resp)
+    resp.__aexit__ = AsyncMock(return_value=False)
+    return resp
+
+
+class TestSuccessfulRequests:
+    @pytest.mark.asyncio
+    async def test_get_json(self):
+        auth = _mock_auth_provider()
+        client = AtlassianHTTPClient(auth, "https://example.com", max_retries=0)
+        resp = _make_response(200, {"ok": True})
+
+        mock_session = MagicMock()
+        mock_session.request = MagicMock(return_value=resp)
+        client._session = mock_session
+
+        result = await client.request("GET", "/api/test")
+        assert result == {"ok": True}
+
+    @pytest.mark.asyncio
+    async def test_non_json_response(self):
+        auth = _mock_auth_provider()
+        client = AtlassianHTTPClient(auth, "https://example.com", max_retries=0)
+        resp = _make_response(200, "plain text", content_type="text/plain")
+
+        mock_session = MagicMock()
+        mock_session.request = MagicMock(return_value=resp)
+        client._session = mock_session
+
+        result = await client.request("GET", "/api/text")
+        assert result["_raw"] == "plain text"
+
+
+class TestRetryLogic:
+    @pytest.mark.asyncio
+    async def test_retries_on_500(self):
+        auth = _mock_auth_provider()
+        client = AtlassianHTTPClient(auth, "https://example.com", max_retries=2)
+
+        fail_resp = _make_response(500, "server error")
+        ok_resp = _make_response(200, {"ok": True})
+
+        call_count = 0
+        def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return fail_resp if call_count <= 1 else ok_resp
+
+        mock_session = MagicMock()
+        mock_session.request = MagicMock(side_effect=side_effect)
+        client._session = mock_session
+
+        with patch("src.atlassian.http_client.asyncio.sleep", new_callable=AsyncMock):
+            result = await client.request("GET", "/api/test")
+        assert result == {"ok": True}
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_raises_after_max_retries(self):
+        auth = _mock_auth_provider()
+        client = AtlassianHTTPClient(auth, "https://example.com", max_retries=1)
+
+        fail_resp = _make_response(502, "bad gateway")
+        mock_session = MagicMock()
+        mock_session.request = MagicMock(return_value=fail_resp)
+        client._session = mock_session
+
+        with patch("src.atlassian.http_client.asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(AtlassianAPIError, match="502"):
+                await client.request("GET", "/api/fail")
+
+
+class TestAuthRefresh:
+    @pytest.mark.asyncio
+    async def test_401_triggers_refresh_and_retry(self):
+        auth = _mock_auth_provider()
+        client = AtlassianHTTPClient(auth, "https://example.com", max_retries=2)
+
+        unauth_resp = _make_response(401, "unauthorized")
+        ok_resp = _make_response(200, {"ok": True})
+
+        call_count = 0
+        def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return unauth_resp if call_count <= 1 else ok_resp
+
+        mock_session = MagicMock()
+        mock_session.request = MagicMock(side_effect=side_effect)
+        client._session = mock_session
+
+        result = await client.request("GET", "/api/test")
+        assert result == {"ok": True}
+        auth.refresh_if_needed.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_double_401_raises(self):
+        auth = _mock_auth_provider()
+        client = AtlassianHTTPClient(auth, "https://example.com", max_retries=2)
+
+        unauth_resp = _make_response(401, "unauthorized")
+        mock_session = MagicMock()
+        mock_session.request = MagicMock(return_value=unauth_resp)
+        client._session = mock_session
+
+        with pytest.raises(AtlassianAuthError, match="Authentication failed"):
+            await client.request("GET", "/api/test")
+
+
+class TestRateLimit:
+    @pytest.mark.asyncio
+    async def test_429_respects_retry_after(self):
+        auth = _mock_auth_provider()
+        client = AtlassianHTTPClient(auth, "https://example.com", max_retries=2)
+
+        rate_resp = _make_response(429, "rate limited", headers={"Retry-After": "1"})
+        ok_resp = _make_response(200, {"ok": True})
+
+        call_count = 0
+        def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return rate_resp if call_count <= 1 else ok_resp
+
+        mock_session = MagicMock()
+        mock_session.request = MagicMock(side_effect=side_effect)
+        client._session = mock_session
+
+        with patch("src.atlassian.http_client.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await client.request("GET", "/api/test")
+        assert result == {"ok": True}
+        mock_sleep.assert_called_once_with(1.0)
+
+    @pytest.mark.asyncio
+    async def test_429_raises_after_retries(self):
+        auth = _mock_auth_provider()
+        client = AtlassianHTTPClient(auth, "https://example.com", max_retries=0)
+
+        rate_resp = _make_response(429, "rate limited")
+        mock_session = MagicMock()
+        mock_session.request = MagicMock(return_value=rate_resp)
+        client._session = mock_session
+
+        with pytest.raises(AtlassianRateLimitError):
+            await client.request("GET", "/api/test")
+
+
+class TestNotInitialized:
+    @pytest.mark.asyncio
+    async def test_raises_if_not_initialized(self):
+        auth = _mock_auth_provider()
+        client = AtlassianHTTPClient(auth, "https://example.com")
+        with pytest.raises(RuntimeError, match="not initialized"):
+            await client.request("GET", "/")

--- a/tests/test_atlassian/test_oauth2_auth.py
+++ b/tests/test_atlassian/test_oauth2_auth.py
@@ -1,0 +1,126 @@
+"""Tests for OAuth2AuthProvider"""
+
+import time
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from src.atlassian.auth.oauth2_auth import OAuth2AuthProvider, EXPIRY_BUFFER_SECONDS
+from src.atlassian.base import AuthMethod, AtlassianConfigError, AtlassianAuthError
+
+
+def _config(overrides=None):
+    cfg = {
+        "oauth2_client_id": "cid",
+        "oauth2_client_secret": "csecret",
+        "base_url": "https://myorg.atlassian.net",
+        "oauth2_access_token": "access-tok",
+        "oauth2_refresh_token": "refresh-tok",
+        "oauth2_token_expires_at": str(time.time() + 7200),
+    }
+    if overrides:
+        cfg.update(overrides)
+    return cfg
+
+
+class TestValidation:
+    def test_valid(self):
+        p = OAuth2AuthProvider(_config())
+        assert p.client_id == "cid"
+
+    def test_missing_client_id(self):
+        with pytest.raises(AtlassianConfigError, match="oauth2_client_id"):
+            OAuth2AuthProvider(_config({"oauth2_client_id": ""}))
+
+    def test_missing_tokens(self):
+        with pytest.raises(AtlassianConfigError, match="oauth2_access_token or oauth2_refresh_token"):
+            OAuth2AuthProvider(_config({
+                "oauth2_access_token": None,
+                "oauth2_refresh_token": None,
+            }))
+
+    def test_refresh_token_only_is_ok(self):
+        p = OAuth2AuthProvider(_config({"oauth2_access_token": None}))
+        assert p._refresh_token == "refresh-tok"
+
+
+class TestHeaders:
+    @pytest.mark.asyncio
+    async def test_bearer_header(self):
+        p = OAuth2AuthProvider(_config())
+        auth = await p.get_auth_headers()
+        assert auth.headers["Authorization"] == "Bearer access-tok"
+        assert auth.auth_method == AuthMethod.OAUTH2
+        assert auth.expires_at is not None
+
+
+class TestTokenValidity:
+    @pytest.mark.asyncio
+    async def test_valid_token(self):
+        p = OAuth2AuthProvider(_config())
+        assert await p.is_token_valid() is True
+
+    @pytest.mark.asyncio
+    async def test_expired_token(self):
+        p = OAuth2AuthProvider(_config({"oauth2_token_expires_at": str(time.time() - 100)}))
+        assert await p.is_token_valid() is False
+
+    @pytest.mark.asyncio
+    async def test_no_expiry_assumed_valid(self):
+        p = OAuth2AuthProvider(_config())
+        p._expires_at = None
+        assert await p.is_token_valid() is True
+
+
+class TestRefresh:
+    @pytest.mark.asyncio
+    async def test_refresh_when_near_expiry(self):
+        cfg = _config({"oauth2_token_expires_at": str(time.time() + 60)})  # within buffer
+        p = OAuth2AuthProvider(cfg)
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "expires_in": 3600,
+        })
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.post = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("src.atlassian.auth.oauth2_auth.aiohttp.ClientSession", return_value=mock_session):
+            await p.refresh_if_needed()
+            assert p._access_token == "new-access"
+            assert p._refresh_token == "new-refresh"
+
+    @pytest.mark.asyncio
+    async def test_no_refresh_when_far_from_expiry(self):
+        cfg = _config({"oauth2_token_expires_at": str(time.time() + 7200)})
+        p = OAuth2AuthProvider(cfg)
+        original_token = p._access_token
+        await p.refresh_if_needed()
+        assert p._access_token == original_token
+
+    @pytest.mark.asyncio
+    async def test_refresh_failure_raises(self):
+        cfg = _config({"oauth2_token_expires_at": str(time.time() + 60)})
+        p = OAuth2AuthProvider(cfg)
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 400
+        mock_resp.text = AsyncMock(return_value="bad request")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.post = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("src.atlassian.auth.oauth2_auth.aiohttp.ClientSession", return_value=mock_session):
+            with pytest.raises(AtlassianAuthError, match="Token refresh failed"):
+                await p.refresh_if_needed()

--- a/tests/test_atlassian/test_pat_auth.py
+++ b/tests/test_atlassian/test_pat_auth.py
@@ -1,0 +1,65 @@
+"""Tests for PATAuthProvider"""
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from src.atlassian.auth.pat_auth import PATAuthProvider
+from src.atlassian.base import AuthMethod, AtlassianConfigError
+
+
+def _config(overrides=None):
+    cfg = {
+        "pat": "my-personal-access-token",
+        "base_url": "https://confluence.corp.local",
+    }
+    if overrides:
+        cfg.update(overrides)
+    return cfg
+
+
+class TestValidation:
+    def test_valid(self):
+        p = PATAuthProvider(_config())
+        assert p.pat == "my-personal-access-token"
+
+    def test_missing_pat(self):
+        with pytest.raises(AtlassianConfigError, match="pat"):
+            PATAuthProvider(_config({"pat": ""}))
+
+    def test_missing_base_url(self):
+        with pytest.raises(AtlassianConfigError, match="base_url"):
+            PATAuthProvider(_config({"base_url": ""}))
+
+
+class TestHeaders:
+    @pytest.mark.asyncio
+    async def test_bearer_header(self):
+        p = PATAuthProvider(_config())
+        auth = await p.get_auth_headers()
+        assert auth.headers["Authorization"] == "Bearer my-personal-access-token"
+        assert auth.auth_method == AuthMethod.PAT
+
+    @pytest.mark.asyncio
+    async def test_token_always_valid(self):
+        p = PATAuthProvider(_config())
+        assert await p.is_token_valid() is True
+
+
+class TestHealthCheck:
+    @pytest.mark.asyncio
+    async def test_healthy(self):
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("src.atlassian.auth.pat_auth.aiohttp.ClientSession", return_value=mock_session):
+            p = PATAuthProvider(_config())
+            health = await p.health_check()
+            assert health.is_healthy
+            assert health.auth_method == "pat"


### PR DESCRIPTION
## Summary

- **Auth providers**: `BasicAuthProvider`, `PATAuthProvider`, `OAuth2AuthProvider` with abstract base class, supporting Cloud and On-Prem/Data Center deployments
- **HTTP client**: `AtlassianHTTPClient` with retry logic, rate-limit handling (429 + Retry-After), auth header injection, and SSL configuration
- **Config**: `ConfluenceConfig.from_env()` with auto-detection of deployment type and auth method from environment variables
- **Factory**: `AtlassianAuthFactory` for dynamic provider instantiation
- **Scripts**: `confluence_oauth_setup.py` (OAuth2 flow helper) and `validate_confluence_config.py`
- **42 unit tests** across 7 test files covering auth providers, HTTP client retry/rate-limit, config validation, and factory

## Test plan

- [x] `pytest tests/test_atlassian/ -v` — all tests pass
- [x] `python -c "from src.atlassian import AtlassianHTTPClient, ConfluenceConfig"` — imports OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)