### PR TITLE
feat: Confluence RAG integration (Stories 3.1–3.4)

### DIFF
--- a/src/atlassian/confluence_crawler.py
+++ b/src/atlassian/confluence_crawler.py
@@ -94,33 +94,52 @@ class ConfluenceCrawler:
         page_id = self._parse_page_id_from_url(url)
         return await self.crawl_page(page_id)
 
-    async def crawl_space(self, space_key: str) -> CrawlResult:
-        """Crawl all pages in a Confluence space (paginated)."""
+    async def crawl_space(self, space_key: str, *, max_pages: Optional[int] = None) -> CrawlResult:
+        """Crawl all pages in a Confluence space (paginated).
+
+        Args:
+            space_key: The Confluence space key.
+            max_pages: Override the instance ``max_pages`` for this call.
+        """
+        effective_max_pages = max_pages if max_pages is not None else self.max_pages
         result = CrawlResult(space_key=space_key)
 
         if self.is_cloud:
-            page_ids = await self._list_space_pages_cloud(space_key)
+            page_ids = await self._list_space_pages_cloud(space_key, max_pages=effective_max_pages)
         else:
-            page_ids = await self._list_space_pages_onprem(space_key)
+            page_ids = await self._list_space_pages_onprem(space_key, max_pages=effective_max_pages)
 
-        for pid in page_ids[: self.max_pages]:
+        for pid in page_ids[: effective_max_pages]:
             if pid in result.summary.page_ids_crawled:
                 continue
             await self._safe_crawl_page(pid, result)
 
         return result
 
-    async def crawl_page_tree(self, root_page_id: str) -> CrawlResult:
+    async def crawl_page_tree(
+        self,
+        root_page_id: str,
+        *,
+        max_pages: Optional[int] = None,
+        max_depth: Optional[int] = None,
+    ) -> CrawlResult:
         """BFS crawl of a page tree starting from *root_page_id*.
 
         Respects ``max_depth`` and ``max_pages``. Skips 403/404 pages.
+
+        Args:
+            root_page_id: The root page to start crawling from.
+            max_pages: Override the instance ``max_pages`` for this call.
+            max_depth: Override the instance ``max_depth`` for this call.
         """
+        effective_max_pages = max_pages if max_pages is not None else self.max_pages
+        effective_max_depth = max_depth if max_depth is not None else self.max_depth
         result = CrawlResult()
         queue: deque = deque()
         queue.append((root_page_id, 0))
         visited: Set[str] = set()
 
-        while queue and len(result.summary.page_ids_crawled) < self.max_pages:
+        while queue and len(result.summary.page_ids_crawled) < effective_max_pages:
             page_id, depth = queue.popleft()
 
             if page_id in visited:
@@ -131,7 +150,7 @@ class ConfluenceCrawler:
             if page is None:
                 continue
 
-            if depth < self.max_depth:
+            if depth < effective_max_depth:
                 children = await self._get_child_page_ids(page_id)
                 for child_id in children:
                     if child_id not in visited:
@@ -151,8 +170,9 @@ class ConfluenceCrawler:
         )
         return self._parse_cloud_page(data)
 
-    async def _list_space_pages_cloud(self, space_key: str) -> List[str]:
+    async def _list_space_pages_cloud(self, space_key: str, *, max_pages: Optional[int] = None) -> List[str]:
         """List page IDs in a Cloud space using cursor pagination."""
+        effective_max_pages = max_pages if max_pages is not None else self.max_pages
         page_ids: List[str] = []
         # First resolve space ID from space key
         spaces_data = await self.client.request(
@@ -167,7 +187,7 @@ class ConfluenceCrawler:
         space_id = results[0]["id"]
 
         cursor: Optional[str] = None
-        while len(page_ids) < self.max_pages:
+        while len(page_ids) < effective_max_pages:
             params: Dict[str, Any] = {"limit": 25}
             if cursor:
                 params["cursor"] = cursor
@@ -252,13 +272,14 @@ class ConfluenceCrawler:
         )
         return self._parse_onprem_page(data)
 
-    async def _list_space_pages_onprem(self, space_key: str) -> List[str]:
+    async def _list_space_pages_onprem(self, space_key: str, *, max_pages: Optional[int] = None) -> List[str]:
         """List page IDs in an On-Prem space using offset pagination."""
+        effective_max_pages = max_pages if max_pages is not None else self.max_pages
         page_ids: List[str] = []
         start = 0
         limit = 25
 
-        while len(page_ids) < self.max_pages:
+        while len(page_ids) < effective_max_pages:
             data = await self.client.request(
                 "GET",
                 "/rest/api/content",

--- a/src/crawl4ai_mcp.py
+++ b/src/crawl4ai_mcp.py
@@ -121,6 +121,8 @@ class Crawl4AIContext:
     reranking_model: Optional[CrossEncoder] = None
     knowledge_validator: Optional[Any] = None  # KnowledgeGraphValidator when available
     repo_extractor: Optional[Any] = None       # DirectNeo4jExtractor when available
+    confluence_crawler: Optional[Any] = None   # ConfluenceCrawler when available
+    confluence_processor: Optional[Any] = None # ConfluenceProcessor when available
 
 @asynccontextmanager
 async def crawl4ai_lifespan(server: FastMCP) -> AsyncIterator[Crawl4AIContext]:
@@ -189,14 +191,38 @@ async def crawl4ai_lifespan(server: FastMCP) -> AsyncIterator[Crawl4AIContext]:
             print("Neo4j credentials not configured - knowledge graph tools will be unavailable")
     else:
         print("Knowledge graph functionality disabled - set USE_KNOWLEDGE_GRAPH=true to enable")
-    
+
+    # Initialize Confluence components if configured
+    confluence_crawler_inst = None
+    confluence_processor_inst = None
+    confluence_http_client = None
+    confluence_url = os.getenv("CONFLUENCE_URL")
+    if confluence_url:
+        try:
+            from src.atlassian import AtlassianAuthFactory, ConfluenceCrawler, ConfluenceProcessor
+            from src.atlassian.config import ConfluenceConfig
+            from src.atlassian.base import DeploymentType
+
+            config = ConfluenceConfig.from_env()
+            confluence_http_client = AtlassianAuthFactory.create_http_client(config)
+            confluence_crawler_inst = ConfluenceCrawler(confluence_http_client, config.deployment_type)
+            confluence_processor_inst = ConfluenceProcessor(supabase_client)
+            print("✓ Confluence integration initialized")
+        except Exception as e:
+            print(f"Failed to initialize Confluence: {e}")
+            confluence_crawler_inst = None
+            confluence_processor_inst = None
+            confluence_http_client = None
+
     try:
         yield Crawl4AIContext(
             crawler=crawler,
             supabase_client=supabase_client,
             reranking_model=reranking_model,
             knowledge_validator=knowledge_validator,
-            repo_extractor=repo_extractor
+            repo_extractor=repo_extractor,
+            confluence_crawler=confluence_crawler_inst,
+            confluence_processor=confluence_processor_inst,
         )
     finally:
         # Clean up all components
@@ -213,6 +239,12 @@ async def crawl4ai_lifespan(server: FastMCP) -> AsyncIterator[Crawl4AIContext]:
                 print("✓ Repository extractor closed")
             except Exception as e:
                 print(f"Error closing repository extractor: {e}")
+        if confluence_http_client:
+            try:
+                await confluence_http_client.close()
+                print("✓ Confluence HTTP client closed")
+            except Exception as e:
+                print(f"Error closing Confluence HTTP client: {e}")
 
 # Initialize FastMCP server
 mcp = FastMCP(
@@ -225,6 +257,262 @@ mcp = FastMCP(
 
 # Note: FastMCP doesn't support HTTP endpoints like Flask/FastAPI
 # Health checking will be done through MCP tools instead
+
+# ---------------------------------------------------------------------------
+# Confluence MCP tools (conditionally registered when CONFLUENCE_URL is set)
+# ---------------------------------------------------------------------------
+if os.getenv("CONFLUENCE_URL"):
+
+    @mcp.tool()
+    async def crawl_confluence_space(ctx: Context, space_key: str, max_pages: int = 500) -> str:
+        """
+        Crawl all pages in a Confluence space and store content for RAG queries.
+
+        This tool fetches every page in the given space, converts content to Markdown,
+        chunks it, generates embeddings, and stores everything in the vector database.
+
+        Args:
+            ctx: The MCP server provided context
+            space_key: The Confluence space key (e.g. "DEV", "ENG")
+            max_pages: Maximum number of pages to crawl (default: 500)
+
+        Returns:
+            JSON string with crawl and storage summary
+        """
+        try:
+            confluence_crawler = ctx.request_context.lifespan_context.confluence_crawler
+            confluence_processor = ctx.request_context.lifespan_context.confluence_processor
+
+            if not confluence_crawler or not confluence_processor:
+                return json.dumps({
+                    "success": False,
+                    "error": "Confluence integration not initialized. Check CONFLUENCE_URL and credentials."
+                }, indent=2)
+
+            # Override max_pages for this crawl
+            original_max = confluence_crawler.max_pages
+            confluence_crawler.max_pages = max_pages
+            try:
+                crawl_result = await confluence_crawler.crawl_space(space_key)
+            finally:
+                confluence_crawler.max_pages = original_max
+
+            processing_result = await confluence_processor.process_crawl_result(crawl_result)
+
+            return json.dumps({
+                "success": True,
+                "space_key": space_key,
+                "pages_crawled": crawl_result.summary.pages_succeeded,
+                "pages_failed": crawl_result.summary.pages_failed,
+                "chunks_stored": processing_result.summary.total_chunks_stored,
+                "code_examples_stored": processing_result.summary.total_code_examples_stored,
+                "source_id": processing_result.source_id,
+                "errors": crawl_result.summary.errors[:10] if crawl_result.summary.errors else [],
+            }, indent=2)
+        except Exception as e:
+            return json.dumps({
+                "success": False,
+                "space_key": space_key,
+                "error": str(e),
+            }, indent=2)
+
+    @mcp.tool()
+    async def crawl_confluence_page(
+        ctx: Context,
+        page_id: str = None,
+        page_url: str = None,
+        include_children: bool = False,
+        max_depth: int = 5,
+    ) -> str:
+        """
+        Crawl a single Confluence page (or a page tree) and store content for RAG queries.
+
+        Provide either page_id or page_url. When include_children is True, the tool
+        performs a breadth-first crawl of the page tree up to max_depth levels.
+
+        Args:
+            ctx: The MCP server provided context
+            page_id: Confluence page ID (numeric string)
+            page_url: Full URL of the Confluence page
+            include_children: If True, also crawl child pages recursively (default: False)
+            max_depth: Maximum depth when crawling children (default: 5)
+
+        Returns:
+            JSON string with crawl and storage summary
+        """
+        try:
+            if not page_id and not page_url:
+                return json.dumps({
+                    "success": False,
+                    "error": "Either page_id or page_url is required.",
+                }, indent=2)
+
+            confluence_crawler = ctx.request_context.lifespan_context.confluence_crawler
+            confluence_processor = ctx.request_context.lifespan_context.confluence_processor
+
+            if not confluence_crawler or not confluence_processor:
+                return json.dumps({
+                    "success": False,
+                    "error": "Confluence integration not initialized. Check CONFLUENCE_URL and credentials."
+                }, indent=2)
+
+            from src.atlassian.confluence_crawler import CrawlResult
+
+            if page_url and not page_id:
+                page = await confluence_crawler.crawl_page_by_url(page_url)
+                page_id = page.page_id
+                if not include_children:
+                    crawl_result = CrawlResult(pages=[page])
+                    crawl_result.summary.pages_succeeded = 1
+                    crawl_result.summary.page_ids_crawled.add(page_id)
+                else:
+                    original_depth = confluence_crawler.max_depth
+                    confluence_crawler.max_depth = max_depth
+                    try:
+                        crawl_result = await confluence_crawler.crawl_page_tree(page_id)
+                    finally:
+                        confluence_crawler.max_depth = original_depth
+            elif include_children:
+                original_depth = confluence_crawler.max_depth
+                confluence_crawler.max_depth = max_depth
+                try:
+                    crawl_result = await confluence_crawler.crawl_page_tree(page_id)
+                finally:
+                    confluence_crawler.max_depth = original_depth
+            else:
+                page = await confluence_crawler.crawl_page(page_id)
+                crawl_result = CrawlResult(pages=[page])
+                crawl_result.summary.pages_succeeded = 1
+                crawl_result.summary.page_ids_crawled.add(page_id)
+
+            processing_result = await confluence_processor.process_crawl_result(crawl_result)
+
+            return json.dumps({
+                "success": True,
+                "page_id": page_id,
+                "pages_crawled": crawl_result.summary.pages_succeeded,
+                "pages_failed": crawl_result.summary.pages_failed,
+                "chunks_stored": processing_result.summary.total_chunks_stored,
+                "code_examples_stored": processing_result.summary.total_code_examples_stored,
+                "source_id": processing_result.source_id,
+                "include_children": include_children,
+            }, indent=2)
+        except Exception as e:
+            return json.dumps({
+                "success": False,
+                "page_id": page_id,
+                "page_url": page_url,
+                "error": str(e),
+            }, indent=2)
+
+    @mcp.tool()
+    async def get_confluence_sources(ctx: Context) -> str:
+        """
+        List all Confluence sources that have been crawled and stored.
+
+        Returns source IDs, summaries, word counts, and chunk counts for each
+        Confluence space that has been ingested. Useful for discovering what
+        Confluence content is available for RAG queries.
+
+        Args:
+            ctx: The MCP server provided context
+
+        Returns:
+            JSON string with the list of Confluence sources and their details
+        """
+        try:
+            supabase_client = ctx.request_context.lifespan_context.supabase_client
+
+            # Query sources table for confluence sources
+            result = supabase_client.from_('sources')\
+                .select('*')\
+                .like('source_id', 'confluence:%')\
+                .order('source_id')\
+                .execute()
+
+            sources = []
+            if result.data:
+                for source in result.data:
+                    source_id = source.get("source_id")
+
+                    # Get chunk count for this source
+                    chunk_result = supabase_client.from_('crawled_pages')\
+                        .select('id', count='exact')\
+                        .eq('source_id', source_id)\
+                        .execute()
+                    chunk_count = chunk_result.count if chunk_result.count is not None else 0
+
+                    sources.append({
+                        "source_id": source_id,
+                        "summary": source.get("summary"),
+                        "total_words": source.get("total_words"),
+                        "chunk_count": chunk_count,
+                        "created_at": source.get("created_at"),
+                        "updated_at": source.get("updated_at"),
+                    })
+
+            return json.dumps({
+                "success": True,
+                "sources": sources,
+                "count": len(sources),
+            }, indent=2)
+        except Exception as e:
+            return json.dumps({
+                "success": False,
+                "error": str(e),
+            }, indent=2)
+
+    @mcp.tool()
+    async def sync_confluence_space(ctx: Context, space_key: str, force_full: bool = False) -> str:
+        """
+        Sync a previously crawled Confluence space, updating only changed pages.
+
+        By default performs an incremental sync — pages whose last_modified timestamp
+        hasn't changed are skipped. Set force_full=True to re-process every page and
+        also detect deleted pages whose chunks should be removed.
+
+        Args:
+            ctx: The MCP server provided context
+            space_key: The Confluence space key (e.g. "DEV", "ENG")
+            force_full: If True, reprocess all pages and delete orphaned chunks (default: False)
+
+        Returns:
+            JSON string with sync summary including pages updated, unchanged, and deleted
+        """
+        try:
+            confluence_crawler = ctx.request_context.lifespan_context.confluence_crawler
+            confluence_processor = ctx.request_context.lifespan_context.confluence_processor
+
+            if not confluence_crawler or not confluence_processor:
+                return json.dumps({
+                    "success": False,
+                    "error": "Confluence integration not initialized. Check CONFLUENCE_URL and credentials."
+                }, indent=2)
+
+            crawl_result = await confluence_crawler.crawl_space(space_key)
+            processing_result = await confluence_processor.process_crawl_result(
+                crawl_result, detect_deletions=force_full
+            )
+
+            return json.dumps({
+                "success": True,
+                "space_key": space_key,
+                "force_full": force_full,
+                "pages_checked": crawl_result.summary.pages_succeeded,
+                "pages_updated": processing_result.summary.pages_processed,
+                "pages_unchanged": processing_result.summary.pages_skipped_unchanged,
+                "pages_skipped_empty": processing_result.summary.pages_skipped_empty,
+                "pages_failed": processing_result.summary.pages_failed,
+                "chunks_stored": processing_result.summary.total_chunks_stored,
+                "orphaned_deleted": processing_result.summary.orphaned_pages_deleted,
+                "source_id": processing_result.source_id,
+            }, indent=2)
+        except Exception as e:
+            return json.dumps({
+                "success": False,
+                "space_key": space_key,
+                "error": str(e),
+            }, indent=2)
 
 @mcp.tool()
 async def health_check(ctx: Context) -> str:
@@ -924,20 +1212,22 @@ async def get_available_sources(ctx: Context) -> str:
         }, indent=2)
 
 @mcp.tool()
-async def perform_rag_query(ctx: Context, query: str, source: str = None, match_count: int = 5) -> str:
+async def perform_rag_query(ctx: Context, query: str, source: str = None, match_count: int = 5, source_type: str = None) -> str:
     """
     Perform a RAG (Retrieval Augmented Generation) query on the stored content.
-    
+
     This tool searches the vector database for content relevant to the query and returns
-    the matching documents. Optionally filter by source domain.
+    the matching documents. Optionally filter by source domain and/or source type.
     Get the source by using the get_available_sources tool before calling this search!
-    
+
     Args:
         ctx: The MCP server provided context
         query: The search query
         source: Optional source domain to filter results (e.g., 'example.com')
         match_count: Maximum number of results to return (default: 5)
-    
+        source_type: Optional content type filter: "confluence" (only Confluence content),
+                     "web" (only web-crawled content), or None/omit for all content
+
     Returns:
         JSON string with the search results
     """
@@ -955,7 +1245,7 @@ async def perform_rag_query(ctx: Context, query: str, source: str = None, match_
         
         if use_hybrid_search:
             # Hybrid search: combine vector and keyword search
-            
+
             # 1. Get vector search results (get more to account for filtering)
             vector_results = search_documents(
                 client=supabase_client,
@@ -963,16 +1253,28 @@ async def perform_rag_query(ctx: Context, query: str, source: str = None, match_
                 match_count=match_count * 2,  # Get double to have room for filtering
                 filter_metadata=filter_metadata
             )
-            
+
+            # Apply source_type post-filter to vector results
+            if source_type == "confluence":
+                vector_results = [r for r in vector_results if r.get("source_id", "").startswith("confluence:")]
+            elif source_type == "web":
+                vector_results = [r for r in vector_results if not r.get("source_id", "").startswith("confluence:")]
+
             # 2. Get keyword search results using ILIKE
             keyword_query = supabase_client.from_('crawled_pages')\
                 .select('id, url, chunk_number, content, metadata, source_id')\
                 .ilike('content', f'%{query}%')
-            
+
             # Apply source filter if provided
             if source and source.strip():
                 keyword_query = keyword_query.eq('source_id', source)
-            
+
+            # Apply source_type filter
+            if source_type == "confluence":
+                keyword_query = keyword_query.like('source_id', 'confluence:%')
+            elif source_type == "web":
+                keyword_query = keyword_query.not_.like('source_id', 'confluence:%')
+
             # Execute keyword search
             keyword_response = keyword_query.limit(match_count * 2).execute()
             keyword_results = keyword_response.data if keyword_response.data else []
@@ -1023,10 +1325,18 @@ async def perform_rag_query(ctx: Context, query: str, source: str = None, match_
             results = search_documents(
                 client=supabase_client,
                 query=query,
-                match_count=match_count,
+                match_count=match_count * 2 if source_type else match_count,
                 filter_metadata=filter_metadata
             )
-        
+
+            # Apply source_type post-filter
+            if source_type == "confluence":
+                results = [r for r in results if r.get("source_id", "").startswith("confluence:")]
+            elif source_type == "web":
+                results = [r for r in results if not r.get("source_id", "").startswith("confluence:")]
+
+            results = results[:match_count]
+
         # Apply reranking if enabled
         use_reranking = os.getenv("USE_RERANKING", "false") == "true"
         if use_reranking and ctx.request_context.lifespan_context.reranking_model:
@@ -1050,6 +1360,7 @@ async def perform_rag_query(ctx: Context, query: str, source: str = None, match_
             "success": True,
             "query": query,
             "source_filter": source,
+            "source_type_filter": source_type,
             "search_mode": "hybrid" if use_hybrid_search else "vector",
             "reranking_applied": use_reranking and ctx.request_context.lifespan_context.reranking_model is not None,
             "results": formatted_results,

--- a/src/crawl4ai_mcp.py
+++ b/src/crawl4ai_mcp.py
@@ -289,13 +289,7 @@ if os.getenv("CONFLUENCE_URL"):
                     "error": "Confluence integration not initialized. Check CONFLUENCE_URL and credentials."
                 }, indent=2)
 
-            # Override max_pages for this crawl
-            original_max = confluence_crawler.max_pages
-            confluence_crawler.max_pages = max_pages
-            try:
-                crawl_result = await confluence_crawler.crawl_space(space_key)
-            finally:
-                confluence_crawler.max_pages = original_max
+            crawl_result = await confluence_crawler.crawl_space(space_key, max_pages=max_pages)
 
             processing_result = await confluence_processor.process_crawl_result(crawl_result)
 
@@ -366,19 +360,9 @@ if os.getenv("CONFLUENCE_URL"):
                     crawl_result.summary.pages_succeeded = 1
                     crawl_result.summary.page_ids_crawled.add(page_id)
                 else:
-                    original_depth = confluence_crawler.max_depth
-                    confluence_crawler.max_depth = max_depth
-                    try:
-                        crawl_result = await confluence_crawler.crawl_page_tree(page_id)
-                    finally:
-                        confluence_crawler.max_depth = original_depth
+                    crawl_result = await confluence_crawler.crawl_page_tree(page_id, max_depth=max_depth)
             elif include_children:
-                original_depth = confluence_crawler.max_depth
-                confluence_crawler.max_depth = max_depth
-                try:
-                    crawl_result = await confluence_crawler.crawl_page_tree(page_id)
-                finally:
-                    confluence_crawler.max_depth = original_depth
+                crawl_result = await confluence_crawler.crawl_page_tree(page_id, max_depth=max_depth)
             else:
                 page = await confluence_crawler.crawl_page(page_id)
                 crawl_result = CrawlResult(pages=[page])

--- a/tests/test_atlassian/test_confluence_mcp_tools.py
+++ b/tests/test_atlassian/test_confluence_mcp_tools.py
@@ -1,0 +1,550 @@
+"""Tests for Confluence MCP tools (Story 3.4).
+
+Since MCP tool functions are defined inside a conditional ``if os.getenv("CONFLUENCE_URL")``
+block, we set that env var and mock heavy dependencies before importing ``src.crawl4ai_mcp``,
+then call the tool coroutines directly with a mocked MCP Context.
+"""
+
+import json
+import os
+import sys
+import types
+import pytest
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# 1. Set CONFLUENCE_URL so conditional tool block is registered on import.
+# ---------------------------------------------------------------------------
+os.environ["CONFLUENCE_URL"] = "https://test.atlassian.net"
+
+# ---------------------------------------------------------------------------
+# 2. Stub heavy third-party / project modules that crawl4ai_mcp imports at
+#    module level so the test suite doesn't need Supabase, Crawl4AI, Neo4j…
+# ---------------------------------------------------------------------------
+
+def _stub_module(name, attrs=None):
+    """Insert a fake module into sys.modules if it isn't already importable."""
+    if name in sys.modules:
+        return
+    mod = types.ModuleType(name)
+    for attr, val in (attrs or {}).items():
+        setattr(mod, attr, val)
+    sys.modules[name] = mod
+
+
+# sentence_transformers
+_stub_module("sentence_transformers", {"CrossEncoder": MagicMock})
+
+# crawl4ai tree
+for _m in [
+    "crawl4ai",
+    "crawl4ai.async_configs",
+]:
+    _stub_module(_m)
+# Provide names imported by crawl4ai_mcp
+_crawl4ai = sys.modules["crawl4ai"]
+for _name in [
+    "AsyncWebCrawler",
+    "BrowserConfig",
+    "CrawlerRunConfig",
+    "CacheMode",
+    "MemoryAdaptiveDispatcher",
+]:
+    setattr(_crawl4ai, _name, MagicMock())
+
+# supabase
+_stub_module("supabase", {"Client": MagicMock, "create_client": MagicMock()})
+
+# openai (used by src/utils.py)
+_openai_mod = types.ModuleType("openai")
+_openai_mod.api_key = None
+sys.modules.setdefault("openai", _openai_mod)
+
+# src.utils — stub so confluence_processor import works without real Supabase/OpenAI
+_stub_module("src.utils", {
+    "get_supabase_client": MagicMock(return_value=MagicMock()),
+    "add_documents_to_supabase": MagicMock(),
+    "search_documents": MagicMock(return_value=[]),
+    "extract_code_blocks": MagicMock(return_value=[]),
+    "generate_code_example_summary": MagicMock(return_value=""),
+    "add_code_examples_to_supabase": MagicMock(),
+    "update_source_info": MagicMock(),
+    "extract_source_summary": MagicMock(return_value=""),
+    "search_code_examples": MagicMock(return_value=[]),
+})
+
+# neo4j (used by knowledge graph modules)
+_stub_module("neo4j", {"GraphDatabase": MagicMock})
+
+# knowledge graph modules (imported via sys.path manipulation in crawl4ai_mcp)
+for _kg_mod in [
+    "knowledge_graph_validator",
+    "parse_repo_into_neo4j",
+    "ai_script_analyzer",
+    "hallucination_reporter",
+]:
+    _stub_module(_kg_mod, {
+        "KnowledgeGraphValidator": MagicMock,
+        "DirectNeo4jExtractor": MagicMock,
+        "AIScriptAnalyzer": MagicMock,
+        "HallucinationReporter": MagicMock,
+    })
+
+# utils (imported as bare "utils" via the sys.path trick in crawl4ai_mcp)
+_stub_module("utils", {
+    "get_supabase_client": MagicMock(return_value=MagicMock()),
+    "add_documents_to_supabase": MagicMock(),
+    "search_documents": MagicMock(return_value=[]),
+    "extract_code_blocks": MagicMock(return_value=[]),
+    "generate_code_example_summary": MagicMock(return_value=""),
+    "add_code_examples_to_supabase": MagicMock(),
+    "update_source_info": MagicMock(),
+    "extract_source_summary": MagicMock(return_value=""),
+    "search_code_examples": MagicMock(return_value=[]),
+})
+
+# mcp.server.fastmcp — provide a stub FastMCP whose @tool() decorator is a no-op passthrough
+class _FakeFastMCP:
+    def __init__(self, *a, **kw):
+        pass
+    def tool(self, *a, **kw):
+        """Decorator that simply returns the function unchanged."""
+        def decorator(fn):
+            return fn
+        return decorator
+
+_stub_module("mcp", {})
+_stub_module("mcp.server", {})
+_stub_module("mcp.server.fastmcp", {
+    "FastMCP": _FakeFastMCP,
+    "Context": type("Context", (), {}),
+})
+
+# dotenv
+_stub_module("dotenv", {"load_dotenv": MagicMock()})
+
+# Now we can import after all stubs are in place.
+# We need to reload / freshly import crawl4ai_mcp since it may have been cached.
+if "src.crawl4ai_mcp" in sys.modules:
+    del sys.modules["src.crawl4ai_mcp"]
+
+import src.crawl4ai_mcp as _mcp_mod  # noqa: E402
+
+from src.atlassian.confluence_crawler import ConfluencePage, CrawlResult, CrawlSummary
+from src.atlassian.confluence_processor import (
+    ProcessingResult,
+    ProcessingSummary,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_page(
+    page_id="101",
+    title="Test Page",
+    space_key="DEV",
+    url="https://acme.atlassian.net/wiki/spaces/DEV/pages/101/Test-Page",
+    content="# Hello\n\nSome content here.",
+    last_modified="2025-06-01T00:00:00Z",
+) -> ConfluencePage:
+    return ConfluencePage(
+        page_id=page_id,
+        title=title,
+        space_key=space_key,
+        url=url,
+        markdown_content=content,
+        author="Alice",
+        last_modified=last_modified,
+        labels=["docs"],
+        parent_page_id="100",
+    )
+
+
+def _make_crawl_result(pages=None, space_key="DEV", failed=0, errors=None):
+    pages = pages or [_make_page()]
+    summary = CrawlSummary(
+        pages_succeeded=len(pages),
+        pages_failed=failed,
+        page_ids_crawled={p.page_id for p in pages},
+        errors=errors or [],
+    )
+    return CrawlResult(pages=pages, summary=summary, space_key=space_key)
+
+
+def _make_processing_result(
+    pages_processed=1,
+    chunks_stored=3,
+    code_examples=0,
+    pages_skipped_unchanged=0,
+    pages_skipped_empty=0,
+    pages_failed=0,
+    orphaned_deleted=0,
+    source_id="confluence:DEV",
+):
+    return ProcessingResult(
+        page_results=[],
+        summary=ProcessingSummary(
+            pages_processed=pages_processed,
+            pages_skipped_unchanged=pages_skipped_unchanged,
+            pages_skipped_empty=pages_skipped_empty,
+            pages_failed=pages_failed,
+            total_chunks_stored=chunks_stored,
+            total_code_examples_stored=code_examples,
+            orphaned_pages_deleted=orphaned_deleted,
+        ),
+        source_id=source_id,
+    )
+
+
+@dataclass
+class _FakeLifespan:
+    confluence_crawler: Any = None
+    confluence_processor: Any = None
+    supabase_client: Any = None
+    reranking_model: Any = None
+
+
+class _FakeRequestContext:
+    def __init__(self, lifespan):
+        self.lifespan_context = lifespan
+
+
+class _FakeContext:
+    def __init__(self, lifespan):
+        self.request_context = _FakeRequestContext(lifespan)
+
+
+def _build_ctx(crawler=None, processor=None, supabase=None):
+    lifespan = _FakeLifespan(
+        confluence_crawler=crawler,
+        confluence_processor=processor,
+        supabase_client=supabase,
+    )
+    return _FakeContext(lifespan)
+
+
+def _tool(name: str):
+    """Get a tool function from the imported crawl4ai_mcp module."""
+    return getattr(_mcp_mod, name)
+
+
+# ===================================================================
+# crawl_confluence_space
+# ===================================================================
+
+
+class TestCrawlConfluenceSpace:
+    @pytest.mark.asyncio
+    async def test_success(self):
+        crawler = AsyncMock()
+        processor = AsyncMock()
+        crawl_result = _make_crawl_result()
+        processing_result = _make_processing_result()
+
+        crawler.crawl_space = AsyncMock(return_value=crawl_result)
+        crawler.max_pages = 100
+        processor.process_crawl_result = AsyncMock(return_value=processing_result)
+
+        ctx = _build_ctx(crawler=crawler, processor=processor)
+        fn = _tool("crawl_confluence_space")
+        raw = await fn(ctx, space_key="DEV", max_pages=500)
+        data = json.loads(raw)
+
+        assert data["success"] is True
+        assert data["space_key"] == "DEV"
+        assert data["pages_crawled"] == 1
+        assert data["chunks_stored"] == 3
+        assert data["source_id"] == "confluence:DEV"
+        crawler.crawl_space.assert_awaited_once_with("DEV")
+
+    @pytest.mark.asyncio
+    async def test_partial_failure(self):
+        pages = [_make_page(page_id="1"), _make_page(page_id="2")]
+        errors = [{"page_id": "3", "error": "403 Forbidden"}]
+        crawl_result = _make_crawl_result(pages=pages, failed=1, errors=errors)
+        processing_result = _make_processing_result(pages_processed=2, chunks_stored=6)
+
+        crawler = AsyncMock()
+        processor = AsyncMock()
+        crawler.crawl_space = AsyncMock(return_value=crawl_result)
+        crawler.max_pages = 100
+        processor.process_crawl_result = AsyncMock(return_value=processing_result)
+
+        ctx = _build_ctx(crawler=crawler, processor=processor)
+        fn = _tool("crawl_confluence_space")
+        raw = await fn(ctx, space_key="DEV")
+        data = json.loads(raw)
+
+        assert data["success"] is True
+        assert data["pages_crawled"] == 2
+        assert data["pages_failed"] == 1
+        assert len(data["errors"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_not_initialized(self):
+        ctx = _build_ctx()
+        fn = _tool("crawl_confluence_space")
+        raw = await fn(ctx, space_key="DEV")
+        data = json.loads(raw)
+
+        assert data["success"] is False
+        assert "not initialized" in data["error"]
+
+
+# ===================================================================
+# crawl_confluence_page
+# ===================================================================
+
+
+class TestCrawlConfluencePage:
+    @pytest.mark.asyncio
+    async def test_by_page_id(self):
+        page = _make_page()
+        crawler = AsyncMock()
+        processor = AsyncMock()
+        crawler.crawl_page = AsyncMock(return_value=page)
+        processing_result = _make_processing_result()
+        processor.process_crawl_result = AsyncMock(return_value=processing_result)
+
+        ctx = _build_ctx(crawler=crawler, processor=processor)
+        fn = _tool("crawl_confluence_page")
+        raw = await fn(ctx, page_id="101")
+        data = json.loads(raw)
+
+        assert data["success"] is True
+        assert data["page_id"] == "101"
+        assert data["include_children"] is False
+        crawler.crawl_page.assert_awaited_once_with("101")
+
+    @pytest.mark.asyncio
+    async def test_by_page_url(self):
+        page = _make_page()
+        crawler = AsyncMock()
+        processor = AsyncMock()
+        crawler.crawl_page_by_url = AsyncMock(return_value=page)
+        processing_result = _make_processing_result()
+        processor.process_crawl_result = AsyncMock(return_value=processing_result)
+
+        ctx = _build_ctx(crawler=crawler, processor=processor)
+        fn = _tool("crawl_confluence_page")
+        raw = await fn(ctx, page_url="https://acme.atlassian.net/wiki/spaces/DEV/pages/101/Test")
+        data = json.loads(raw)
+
+        assert data["success"] is True
+        assert data["page_id"] == "101"
+
+    @pytest.mark.asyncio
+    async def test_with_children(self):
+        crawl_result = _make_crawl_result(
+            pages=[_make_page(page_id="101"), _make_page(page_id="102")]
+        )
+        crawler = AsyncMock()
+        processor = AsyncMock()
+        crawler.crawl_page_tree = AsyncMock(return_value=crawl_result)
+        crawler.max_depth = 5
+        processing_result = _make_processing_result(pages_processed=2, chunks_stored=6)
+        processor.process_crawl_result = AsyncMock(return_value=processing_result)
+
+        ctx = _build_ctx(crawler=crawler, processor=processor)
+        fn = _tool("crawl_confluence_page")
+        raw = await fn(ctx, page_id="101", include_children=True, max_depth=3)
+        data = json.loads(raw)
+
+        assert data["success"] is True
+        assert data["include_children"] is True
+        assert data["pages_crawled"] == 2
+
+    @pytest.mark.asyncio
+    async def test_neither_id_nor_url(self):
+        ctx = _build_ctx(crawler=AsyncMock(), processor=AsyncMock())
+        fn = _tool("crawl_confluence_page")
+        raw = await fn(ctx)
+        data = json.loads(raw)
+
+        assert data["success"] is False
+        assert "page_id or page_url" in data["error"]
+
+
+# ===================================================================
+# get_confluence_sources
+# ===================================================================
+
+
+class TestGetConfluenceSources:
+    @pytest.mark.asyncio
+    async def test_returns_sources(self):
+        mock_client = MagicMock()
+
+        source_data = [
+            {
+                "source_id": "confluence:DEV",
+                "summary": "Dev docs",
+                "total_words": 5000,
+                "created_at": "2025-01-01",
+                "updated_at": "2025-06-01",
+            }
+        ]
+        source_exec = MagicMock()
+        source_exec.data = source_data
+
+        sources_chain = MagicMock()
+        sources_chain.select.return_value = sources_chain
+        sources_chain.like.return_value = sources_chain
+        sources_chain.order.return_value = sources_chain
+        sources_chain.execute.return_value = source_exec
+
+        chunk_exec = MagicMock()
+        chunk_exec.count = 42
+        chunk_chain = MagicMock()
+        chunk_chain.select.return_value = chunk_chain
+        chunk_chain.eq.return_value = chunk_chain
+        chunk_chain.execute.return_value = chunk_exec
+
+        mock_client.from_.side_effect = [sources_chain, chunk_chain]
+
+        ctx = _build_ctx(supabase=mock_client)
+        fn = _tool("get_confluence_sources")
+        raw = await fn(ctx)
+        data = json.loads(raw)
+
+        assert data["success"] is True
+        assert data["count"] == 1
+        assert data["sources"][0]["source_id"] == "confluence:DEV"
+        assert data["sources"][0]["chunk_count"] == 42
+
+    @pytest.mark.asyncio
+    async def test_no_sources(self):
+        mock_client = MagicMock()
+        exec_result = MagicMock()
+        exec_result.data = []
+
+        chain = MagicMock()
+        chain.select.return_value = chain
+        chain.like.return_value = chain
+        chain.order.return_value = chain
+        chain.execute.return_value = exec_result
+        mock_client.from_.return_value = chain
+
+        ctx = _build_ctx(supabase=mock_client)
+        fn = _tool("get_confluence_sources")
+        raw = await fn(ctx)
+        data = json.loads(raw)
+
+        assert data["success"] is True
+        assert data["count"] == 0
+        assert data["sources"] == []
+
+
+# ===================================================================
+# sync_confluence_space
+# ===================================================================
+
+
+class TestSyncConfluenceSpace:
+    @pytest.mark.asyncio
+    async def test_incremental(self):
+        crawl_result = _make_crawl_result()
+        processing_result = _make_processing_result(
+            pages_processed=0,
+            pages_skipped_unchanged=1,
+            chunks_stored=0,
+        )
+
+        crawler = AsyncMock()
+        processor = AsyncMock()
+        crawler.crawl_space = AsyncMock(return_value=crawl_result)
+        processor.process_crawl_result = AsyncMock(return_value=processing_result)
+
+        ctx = _build_ctx(crawler=crawler, processor=processor)
+        fn = _tool("sync_confluence_space")
+        raw = await fn(ctx, space_key="DEV")
+        data = json.loads(raw)
+
+        assert data["success"] is True
+        assert data["force_full"] is False
+        assert data["pages_unchanged"] == 1
+        assert data["pages_updated"] == 0
+        processor.process_crawl_result.assert_awaited_once_with(
+            crawl_result, detect_deletions=False
+        )
+
+    @pytest.mark.asyncio
+    async def test_force_full_with_deletions(self):
+        crawl_result = _make_crawl_result()
+        processing_result = _make_processing_result(
+            pages_processed=1,
+            chunks_stored=3,
+            orphaned_deleted=2,
+        )
+
+        crawler = AsyncMock()
+        processor = AsyncMock()
+        crawler.crawl_space = AsyncMock(return_value=crawl_result)
+        processor.process_crawl_result = AsyncMock(return_value=processing_result)
+
+        ctx = _build_ctx(crawler=crawler, processor=processor)
+        fn = _tool("sync_confluence_space")
+        raw = await fn(ctx, space_key="DEV", force_full=True)
+        data = json.loads(raw)
+
+        assert data["success"] is True
+        assert data["force_full"] is True
+        assert data["orphaned_deleted"] == 2
+        processor.process_crawl_result.assert_awaited_once_with(
+            crawl_result, detect_deletions=True
+        )
+
+
+# ===================================================================
+# perform_rag_query — source_type filter
+# ===================================================================
+
+
+class TestPerformRagQuerySourceType:
+    @pytest.mark.asyncio
+    async def test_confluence_filter(self):
+        """source_type='confluence' should only return confluence: prefixed results."""
+        mock_search = MagicMock(return_value=[
+            {"id": "1", "url": "https://a.com", "content": "web", "metadata": {}, "similarity": 0.9, "source_id": "a.com"},
+            {"id": "2", "url": "https://b.com", "content": "conf", "metadata": {}, "similarity": 0.8, "source_id": "confluence:DEV"},
+        ])
+
+        lifespan = _FakeLifespan(supabase_client=MagicMock())
+        lifespan.reranking_model = None
+        ctx = _FakeContext(lifespan)
+
+        fn = _tool("perform_rag_query")
+        with patch.object(_mcp_mod, "search_documents", mock_search):
+            raw = await fn(ctx, query="test", source_type="confluence")
+        data = json.loads(raw)
+
+        assert data["success"] is True
+        assert data["source_type_filter"] == "confluence"
+        assert len(data["results"]) == 1
+        assert data["results"][0]["url"] == "https://b.com"
+
+    @pytest.mark.asyncio
+    async def test_no_source_type_returns_all(self):
+        """source_type=None should return all results (backward compatible)."""
+        mock_search = MagicMock(return_value=[
+            {"id": "1", "url": "https://a.com", "content": "web", "metadata": {}, "similarity": 0.9, "source_id": "a.com"},
+            {"id": "2", "url": "https://b.com", "content": "conf", "metadata": {}, "similarity": 0.8, "source_id": "confluence:DEV"},
+        ])
+
+        lifespan = _FakeLifespan(supabase_client=MagicMock())
+        lifespan.reranking_model = None
+        ctx = _FakeContext(lifespan)
+
+        fn = _tool("perform_rag_query")
+        with patch.object(_mcp_mod, "search_documents", mock_search):
+            raw = await fn(ctx, query="test")
+        data = json.loads(raw)
+
+        assert data["success"] is True
+        assert data["source_type_filter"] is None
+        assert len(data["results"]) == 2

--- a/tests/test_atlassian/test_confluence_mcp_tools.py
+++ b/tests/test_atlassian/test_confluence_mcp_tools.py
@@ -247,7 +247,6 @@ class TestCrawlConfluenceSpace:
         processing_result = _make_processing_result()
 
         crawler.crawl_space = AsyncMock(return_value=crawl_result)
-        crawler.max_pages = 100
         processor.process_crawl_result = AsyncMock(return_value=processing_result)
 
         ctx = _build_ctx(crawler=crawler, processor=processor)
@@ -260,7 +259,7 @@ class TestCrawlConfluenceSpace:
         assert data["pages_crawled"] == 1
         assert data["chunks_stored"] == 3
         assert data["source_id"] == "confluence:DEV"
-        crawler.crawl_space.assert_awaited_once_with("DEV")
+        crawler.crawl_space.assert_awaited_once_with("DEV", max_pages=500)
 
     @pytest.mark.asyncio
     async def test_partial_failure(self):
@@ -272,7 +271,6 @@ class TestCrawlConfluenceSpace:
         crawler = AsyncMock()
         processor = AsyncMock()
         crawler.crawl_space = AsyncMock(return_value=crawl_result)
-        crawler.max_pages = 100
         processor.process_crawl_result = AsyncMock(return_value=processing_result)
 
         ctx = _build_ctx(crawler=crawler, processor=processor)
@@ -346,7 +344,6 @@ class TestCrawlConfluencePage:
         crawler = AsyncMock()
         processor = AsyncMock()
         crawler.crawl_page_tree = AsyncMock(return_value=crawl_result)
-        crawler.max_depth = 5
         processing_result = _make_processing_result(pages_processed=2, chunks_stored=6)
         processor.process_crawl_result = AsyncMock(return_value=processing_result)
 
@@ -358,6 +355,7 @@ class TestCrawlConfluencePage:
         assert data["success"] is True
         assert data["include_children"] is True
         assert data["pages_crawled"] == 2
+        crawler.crawl_page_tree.assert_awaited_once_with("101", max_depth=3)
 
     @pytest.mark.asyncio
     async def test_neither_id_nor_url(self):


### PR DESCRIPTION
## Summary
- **Story 3.1**: Atlassian authentication provider with Basic, PAT, and OAuth2 support, plus factory pattern and HTTP client with retry/rate-limit handling
- **Story 3.2**: Confluence content crawler with ADF/XHTML to Markdown conversion, supporting Cloud (v2) and On-Prem/Data Center (v1) APIs
- **Story 3.3**: Confluence content processor that chunks, embeds, and stores crawled pages in the vector DB with incremental sync and orphan detection
- **Story 3.4**: Four MCP tools (`crawl_confluence_space`, `crawl_confluence_page`, `get_confluence_sources`, `sync_confluence_space`), Confluence lifespan initialization, conditional tool registration, and `source_type` filter on `perform_rag_query`

## Test plan
- [ ] `pytest tests/test_atlassian/ -v` — all 171 tests pass
- [ ] Verify Confluence tools only register when `CONFLUENCE_URL` is set
- [ ] Verify `perform_rag_query` with `source_type="confluence"` filters correctly
- [ ] Verify `perform_rag_query` without `source_type` remains backward compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)